### PR TITLE
V2 empty seq

### DIFF
--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/CommaExpressionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/CommaExpressionIterator.java
@@ -35,7 +35,7 @@ public class CommaExpressionIterator extends LocalRuntimeIterator {
 
     @Override
     public Item next() {
-        if(currentChild == null) {
+        if(this._hasNext) {
             return getResult();
         }
         throw new IteratorFlowException("Invalid next() call in Comma expression", getMetadata());
@@ -50,8 +50,9 @@ public class CommaExpressionIterator extends LocalRuntimeIterator {
         this._currentIndex = 0;
         this.results = new ArrayList<>();
 
-        this._children.forEach(c -> c.reset(this._currentDynamicContext));
+        // this._children.forEach(c -> c.reset(this._currentDynamicContext));
         for (RuntimeIterator child:this._children) {
+            child.open(_currentDynamicContext);
             if (child.hasNext()) {
                 results.add(child.next());
             }
@@ -64,26 +65,12 @@ public class CommaExpressionIterator extends LocalRuntimeIterator {
         }
     }
 
-    @Override
-    public void reset(DynamicContext context){
-        super.reset(context);
-        currentChild = null;
-    }
-
-    @Override
-    public boolean hasNext(){
-        return currentChild == null ||
-                this._children.indexOf(currentChild) < this._children.size() - 1 ||
-                currentChild.hasNext();
-    }
-
     protected Item getResult() {
         if (_currentIndex == results.size() - 1)
             _hasNext = false;
         return results.get(_currentIndex++);
     }
 
-    private RuntimeIterator currentChild = null;
     private int _currentIndex;
     private List<Item> results;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/CommaExpressionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/CommaExpressionIterator.java
@@ -46,10 +46,7 @@ public class CommaExpressionIterator extends LocalRuntimeIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
         this._currentIndex = 0;
         this.results = new ArrayList<>();
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/CommaExpressionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/CommaExpressionIterator.java
@@ -17,7 +17,7 @@
  * Author: Stefan Irimescu
  *
  */
- package sparksoniq.jsoniq.runtime.iterator;
+package sparksoniq.jsoniq.runtime.iterator;
 
 import sparksoniq.jsoniq.item.Item;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
@@ -29,20 +29,23 @@ import java.util.List;
 
 public class CommaExpressionIterator extends LocalRuntimeIterator {
 
+    private int _currentIndex;
+    private List<Item> results;
+
     public CommaExpressionIterator(List<RuntimeIterator> childIterators, IteratorMetadata iteratorMetadata) {
         super(childIterators, iteratorMetadata);
     }
 
     @Override
     public Item next() {
-        if(this._hasNext) {
+        if (this._hasNext) {
             return getResult();
         }
         throw new IteratorFlowException("Invalid next() call in Comma expression", getMetadata());
     }
 
     @Override
-    public void open(DynamicContext context){
+    public void open(DynamicContext context) {
         if (this._isOpen)
             throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
         this._isOpen = true;
@@ -51,7 +54,7 @@ public class CommaExpressionIterator extends LocalRuntimeIterator {
         this.results = new ArrayList<>();
 
         // this._children.forEach(c -> c.reset(this._currentDynamicContext));
-        for (RuntimeIterator child:this._children) {
+        for (RuntimeIterator child : this._children) {
             child.open(_currentDynamicContext);
             if (child.hasNext()) {
                 results.add(child.next());
@@ -70,7 +73,4 @@ public class CommaExpressionIterator extends LocalRuntimeIterator {
             _hasNext = false;
         return results.get(_currentIndex++);
     }
-
-    private int _currentIndex;
-    private List<Item> results;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/EmptySequenceIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/EmptySequenceIterator.java
@@ -17,7 +17,7 @@
  * Author: Stefan Irimescu
  *
  */
- package sparksoniq.jsoniq.runtime.iterator;
+package sparksoniq.jsoniq.runtime.iterator;
 
 import sparksoniq.jsoniq.item.Item;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
@@ -29,7 +29,7 @@ public class EmptySequenceIterator extends LocalRuntimeIterator {
     }
 
     @Override
-    public boolean hasNext(){
+    public boolean hasNext() {
         return false;
     }
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/LocalRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/LocalRuntimeIterator.java
@@ -17,7 +17,7 @@
  * Author: Stefan Irimescu
  *
  */
- package sparksoniq.jsoniq.runtime.iterator;
+package sparksoniq.jsoniq.runtime.iterator;
 
 import sparksoniq.exceptions.SparkRuntimeException;
 import sparksoniq.jsoniq.item.Item;
@@ -32,11 +32,12 @@ public abstract class LocalRuntimeIterator extends RuntimeIterator {
     }
 
     @Override
-    public JavaRDD<Item> getRDD()
-    {
+    public JavaRDD<Item> getRDD() {
         throw new SparkRuntimeException("Iterator has no RDDs", getMetadata());
     }
 
     @Override
-    public boolean isRDD(){ return false; }
+    public boolean isRDD() {
+        return false;
+    }
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/RuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/RuntimeIterator.java
@@ -133,7 +133,7 @@ public abstract class RuntimeIterator implements RuntimeIteratorInterface, KryoS
                                                                                                        Class<T> type, E nonAtomicException) {
         iterator.open(_currentDynamicContext);
         Item result = null;
-        if(iterator.hasNext()) {
+        if (iterator.hasNext()) {
             result = iterator.next();
             if (iterator.hasNext()) {
                 throw nonAtomicException;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/RuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/RuntimeIterator.java
@@ -54,7 +54,6 @@ public abstract class RuntimeIterator implements RuntimeIteratorInterface, KryoS
         if (this._isOpen)
             throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
         this._isOpen = true;
-        this._hasNext = true;
         this._currentDynamicContext = context;
     }
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/RuntimeIteratorInterface.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/RuntimeIteratorInterface.java
@@ -17,7 +17,7 @@
  * Author: Stefan Irimescu
  *
  */
- package sparksoniq.jsoniq.runtime.iterator;
+package sparksoniq.jsoniq.runtime.iterator;
 
 import sparksoniq.jsoniq.item.Item;
 import sparksoniq.semantics.DynamicContext;
@@ -26,8 +26,12 @@ import java.io.Serializable;
 
 public interface RuntimeIteratorInterface extends Serializable {
     void open(DynamicContext context);
+
     void close();
+
     void reset(DynamicContext context);
+
     boolean hasNext();
+
     Item next();
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/control/IfRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/control/IfRuntimeIterator.java
@@ -51,10 +51,7 @@ public class IfRuntimeIterator extends LocalRuntimeIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
         _currentIndex = 0;
 
         RuntimeIterator condition = this._children.get(0);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/control/SwitchRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/control/SwitchRuntimeIterator.java
@@ -44,7 +44,13 @@ public class SwitchRuntimeIterator extends LocalRuntimeIterator {
 
     @Override
     public boolean hasNext() {
-        return matchingIterator == null || matchingIterator.hasNext();
+        matchingIterator.open(_currentDynamicContext);
+        boolean returnValue = false;
+        if (matchingIterator.hasNext()) {
+            returnValue = true;
+        }
+        matchingIterator.close();
+        return returnValue;
     }
 
     @Override

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArrayDescendantFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArrayDescendantFunctionIterator.java
@@ -36,7 +36,7 @@ public class ArrayDescendantFunctionIterator extends ArrayFunctionIterator {
         RuntimeIterator sequenceIterator = this._children.get(0);
         List<Item> items = getItemsFromIteratorWithCurrentContext(sequenceIterator);
         getDescendantArrays(items);
-        if(results.size() == 0) {
+        if (results.size() == 0) {
             this._hasNext = false;
         } else {
             this._hasNext = true;
@@ -44,7 +44,7 @@ public class ArrayDescendantFunctionIterator extends ArrayFunctionIterator {
     }
 
     public void getDescendantArrays(List<Item> items) {
-        for (Item item:items) {
+        for (Item item : items) {
             if (item.isArray()) {
                 results.add(item);
                 try {
@@ -52,15 +52,13 @@ public class ArrayDescendantFunctionIterator extends ArrayFunctionIterator {
                 } catch (OperationNotSupportedException e) {
                     e.printStackTrace();
                 }
-            }
-            else if (item.isObject()) {
+            } else if (item.isObject()) {
                 try {
                     getDescendantArrays((List<Item>) item.getValues());
                 } catch (OperationNotSupportedException e) {
                     e.printStackTrace();
                 }
-            }
-            else {
+            } else {
                 // do nothing
             }
         }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArrayDescendantFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArrayDescendantFunctionIterator.java
@@ -26,10 +26,7 @@ public class ArrayDescendantFunctionIterator extends ArrayFunctionIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         _currentIndex = 0;
         results = new ArrayList<>();

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArrayDescendantFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArrayDescendantFunctionIterator.java
@@ -4,6 +4,7 @@ import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.jsoniq.item.Item;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import javax.naming.OperationNotSupportedException;
 import java.util.ArrayList;
@@ -17,17 +18,29 @@ public class ArrayDescendantFunctionIterator extends ArrayFunctionIterator {
     @Override
     public Item next() {
         if (this._hasNext) {
-            if (results == null) {
-                _currentIndex = 0;
-                results = new ArrayList<>();
-                RuntimeIterator sequenceIterator = this._children.get(0);
-                List<Item> items = getItemsFromIteratorWithCurrentContext(sequenceIterator);
-                getDescendantArrays(items);
-            }
             return getResult();
         }
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " DESCENDANT-ARRAYS function",
                 getMetadata());
+    }
+
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
+
+        _currentIndex = 0;
+        results = new ArrayList<>();
+        RuntimeIterator sequenceIterator = this._children.get(0);
+        List<Item> items = getItemsFromIteratorWithCurrentContext(sequenceIterator);
+        getDescendantArrays(items);
+        if(results.size() == 0) {
+            this._hasNext = false;
+        } else {
+            this._hasNext = true;
+        }
     }
 
     public void getDescendantArrays(List<Item> items) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArrayFlattenFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArrayFlattenFunctionIterator.java
@@ -36,7 +36,7 @@ public class ArrayFlattenFunctionIterator extends ArrayFunctionIterator {
         RuntimeIterator sequenceIterator = this._children.get(0);
         List<Item> items = getItemsFromIteratorWithCurrentContext(sequenceIterator);
         flatten(items);
-        if(results.size() == 0) {
+        if (results.size() == 0) {
             this._hasNext = false;
         } else {
             this._hasNext = true;
@@ -44,15 +44,14 @@ public class ArrayFlattenFunctionIterator extends ArrayFunctionIterator {
     }
 
     public void flatten(List<Item> items) {
-        for (Item item:items) {
+        for (Item item : items) {
             if (item.isArray()) {
                 try {
                     flatten(item.getItems());
                 } catch (OperationNotSupportedException e) {
                     e.printStackTrace();
                 }
-            }
-            else {
+            } else {
                 results.add(item);
             }
         }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArrayFlattenFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArrayFlattenFunctionIterator.java
@@ -4,6 +4,7 @@ import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.jsoniq.item.Item;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import javax.naming.OperationNotSupportedException;
 import java.util.ArrayList;
@@ -17,17 +18,29 @@ public class ArrayFlattenFunctionIterator extends ArrayFunctionIterator {
     @Override
     public Item next() {
         if (this._hasNext) {
-            if (results == null) {
-                _currentIndex = 0;
-                results = new ArrayList<>();
-                RuntimeIterator sequenceIterator = this._children.get(0);
-                List<Item> items = getItemsFromIteratorWithCurrentContext(sequenceIterator);
-                flatten(items);
-            }
             return getResult();
         }
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " FLATTEN function",
                 getMetadata());
+    }
+
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
+
+        _currentIndex = 0;
+        results = new ArrayList<>();
+        RuntimeIterator sequenceIterator = this._children.get(0);
+        List<Item> items = getItemsFromIteratorWithCurrentContext(sequenceIterator);
+        flatten(items);
+        if(results.size() == 0) {
+            this._hasNext = false;
+        } else {
+            this._hasNext = true;
+        }
     }
 
     public void flatten(List<Item> items) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArrayFlattenFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArrayFlattenFunctionIterator.java
@@ -26,10 +26,7 @@ public class ArrayFlattenFunctionIterator extends ArrayFunctionIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         _currentIndex = 0;
         results = new ArrayList<>();

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArrayFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArrayFunctionIterator.java
@@ -1,5 +1,6 @@
 package sparksoniq.jsoniq.runtime.iterator.functions.arrays;
 
+import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.jsoniq.item.Item;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.LocalFunctionCallIterator;
@@ -26,10 +27,8 @@ public abstract class ArrayFunctionIterator extends LocalFunctionCallIterator {
     }
 
     public Item getResult() {
-        // if no results return empty sequence
         if (results == null || results.size() == 0) {
-            _hasNext = false;
-            return null;
+            throw new IteratorFlowException("getResult called on an empty list of results", getMetadata());
         }
         if (_currentIndex == results.size() - 1)
             _hasNext = false;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArrayMembersFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArrayMembersFunctionIterator.java
@@ -8,6 +8,7 @@ import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.LocalFunctionCallIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import javax.naming.OperationNotSupportedException;
 import java.util.ArrayList;
@@ -23,27 +24,39 @@ public class ArrayMembersFunctionIterator extends ArrayFunctionIterator {
     @Override
     public Item next() {
         if (this._hasNext) {
-            if (results == null) {
-                _currentIndex = 0;
-                results = new ArrayList<>();
-                RuntimeIterator sequenceIterator = this._children.get(0);
-                List<Item> items= getItemsFromIteratorWithCurrentContext(sequenceIterator);
-                for (Item item:items) {
-                    if (item.isArray()) {
-                        try {
-                            int size = item.getSize();
-                            for (int i = 0; i < size; i++) {
-                                results.add(item.getItemAt(i));
-                            }
-                        } catch (OperationNotSupportedException e) {
-                            e.printStackTrace();
-                        }
-                    }
-                }
-            }
             return getResult();
         }
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + "MEMBERS function",
                 getMetadata());
+    }
+
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
+
+        _currentIndex = 0;
+        results = new ArrayList<>();
+        RuntimeIterator sequenceIterator = this._children.get(0);
+        List<Item> items= getItemsFromIteratorWithCurrentContext(sequenceIterator);
+        for (Item item:items) {
+            if (item.isArray()) {
+                try {
+                    int size = item.getSize();
+                    for (int i = 0; i < size; i++) {
+                        results.add(item.getItemAt(i));
+                    }
+                } catch (OperationNotSupportedException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        if(results.size() == 0) {
+            this._hasNext = false;
+        } else {
+            this._hasNext = true;
+        }
     }
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArrayMembersFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArrayMembersFunctionIterator.java
@@ -30,10 +30,7 @@ public class ArrayMembersFunctionIterator extends ArrayFunctionIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         _currentIndex = 0;
         results = new ArrayList<>();

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArrayMembersFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArrayMembersFunctionIterator.java
@@ -15,8 +15,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class ArrayMembersFunctionIterator extends ArrayFunctionIterator {
-
-
     public ArrayMembersFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, ArrayFunctionOperators.MEMBERS, iteratorMetadata);
     }
@@ -40,8 +38,8 @@ public class ArrayMembersFunctionIterator extends ArrayFunctionIterator {
         _currentIndex = 0;
         results = new ArrayList<>();
         RuntimeIterator sequenceIterator = this._children.get(0);
-        List<Item> items= getItemsFromIteratorWithCurrentContext(sequenceIterator);
-        for (Item item:items) {
+        List<Item> items = getItemsFromIteratorWithCurrentContext(sequenceIterator);
+        for (Item item : items) {
             if (item.isArray()) {
                 try {
                     int size = item.getSize();
@@ -53,7 +51,7 @@ public class ArrayMembersFunctionIterator extends ArrayFunctionIterator {
                 }
             }
         }
-        if(results.size() == 0) {
+        if (results.size() == 0) {
             this._hasNext = false;
         } else {
             this._hasNext = true;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArraySizeFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArraySizeFunctionIterator.java
@@ -34,8 +34,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class ArraySizeFunctionIterator extends ArrayFunctionIterator {
-
-
     public ArraySizeFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, ArrayFunctionOperators.SIZE, iteratorMetadata);
     }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArraySizeFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArraySizeFunctionIterator.java
@@ -49,10 +49,7 @@ public class ArraySizeFunctionIterator extends ArrayFunctionIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         _currentIndex = 0;
         results = new ArrayList<>();

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/base/Functions.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/base/Functions.java
@@ -84,7 +84,7 @@ public class Functions {
 
         buildInFunctions.put(new SparksoniqFunctionSignature(SUBSTRING, 2), SubstringFunctionIterator.class);
         buildInFunctions.put(new SparksoniqFunctionSignature(SUBSTRING, 3), SubstringFunctionIterator.class);
-        for(int i = 0; i <= 100; i++)
+        for (int i = 0; i <= 100; i++)
             buildInFunctions.put(new SparksoniqFunctionSignature(CONCAT, i), ConcatFunctionIterator.class);
 
         buildInFunctions.put(new SparksoniqFunctionSignature(STRINGJOIN, 1), StringJoinFunction.class);
@@ -108,7 +108,7 @@ public class Functions {
 
     public static Class<? extends RuntimeIterator> getFunctionIteratorClass(FunctionCall expression, List<RuntimeIterator> arguments) {
         SparksoniqFunctionSignature functionSignature = new SparksoniqFunctionSignature(expression.getFunctionName(), arguments.size());
-        if(buildInFunctions.containsKey(functionSignature))
+        if (buildInFunctions.containsKey(functionSignature))
             return buildInFunctions.get(functionSignature);
         throw new UnknownFunctionCallException(new IteratorMetadata(expression.getMetadata()));
     }
@@ -224,7 +224,6 @@ public class Functions {
          * function that returns the the angle in radians subtended at the origin by the point on a plane with coordinates (x, y) and the positive x-axis.
          */
         public static final String ATAN2 = "atan2";
-
 
 
         /**

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/base/LocalFunctionCallIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/base/LocalFunctionCallIterator.java
@@ -17,7 +17,7 @@
  * Author: Stefan Irimescu
  *
  */
- package sparksoniq.jsoniq.runtime.iterator.functions.base;
+package sparksoniq.jsoniq.runtime.iterator.functions.base;
 
 import sparksoniq.jsoniq.runtime.iterator.LocalRuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/base/SparksoniqFunctionSignature.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/base/SparksoniqFunctionSignature.java
@@ -1,6 +1,7 @@
 package sparksoniq.jsoniq.runtime.iterator.functions.base;
 
 public class SparksoniqFunctionSignature {
+
     private final int arity;
     private final String functionName;
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/AbsFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/AbsFunctionIterator.java
@@ -14,6 +14,9 @@ import sparksoniq.semantics.DynamicContext;
 import java.util.List;
 
 public class AbsFunctionIterator extends LocalFunctionCallIterator {
+
+    private Item result;
+
     public AbsFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, iteratorMetadata);
     }
@@ -23,8 +26,8 @@ public class AbsFunctionIterator extends LocalFunctionCallIterator {
         if (this.hasNext()) {
             this._hasNext = false;
             return result;
-        } else
-            throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " abs function", getMetadata());
+        }
+        throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " abs function", getMetadata());
     }
 
     @Override
@@ -37,22 +40,17 @@ public class AbsFunctionIterator extends LocalFunctionCallIterator {
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {
             this._hasNext = false;
-        }
-        else {
+        } else {
             Item value = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
             if (Item.isNumeric(value)) {
                 Double result = Math.abs(Item.getNumericValue(value, Double.class));
                 this._hasNext = true;
-                this.result =  new DoubleItem(result,
+                this.result = new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));
-            }
-            else {
+            } else {
                 throw new UnexpectedTypeException("Abs expression has non numeric args " +
                         value.serialize(), getMetadata());
             }
         }
     }
-
-    Item result;
-
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/AbsFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/AbsFunctionIterator.java
@@ -9,6 +9,7 @@ import sparksoniq.jsoniq.runtime.iterator.EmptySequenceIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.LocalFunctionCallIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import java.util.List;
 
@@ -19,28 +20,39 @@ public class AbsFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public Item next() {
-        if (this._hasNext) {
-            RuntimeIterator iterator = this._children.get(0);
-            //TODO refactor empty items
-            if (iterator.getClass() == EmptySequenceIterator.class) {
-                return null;
-            }
-            else {
-                Item value = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
-                if (Item.isNumeric(value)) {
-                    Double result = Math.abs(Item.getNumericValue(value, Double.class));
-                    this._hasNext = false;
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
-                }
-                else {
-                    throw new UnexpectedTypeException("Abs expression has non numeric args " +
-                            value.serialize(), getMetadata());
-                }
-            }
+        if (this.hasNext()) {
+            this._hasNext = false;
+            return result;
         } else
             throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " abs function", getMetadata());
     }
 
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
+
+        RuntimeIterator iterator = this._children.get(0);
+        if (iterator.getClass() == EmptySequenceIterator.class) {
+            this._hasNext = false;
+        }
+        else {
+            Item value = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
+            if (Item.isNumeric(value)) {
+                Double result = Math.abs(Item.getNumericValue(value, Double.class));
+                this._hasNext = true;
+                this.result =  new DoubleItem(result,
+                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+            }
+            else {
+                throw new UnexpectedTypeException("Abs expression has non numeric args " +
+                        value.serialize(), getMetadata());
+            }
+        }
+    }
+
+    Item result;
 
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/AbsFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/AbsFunctionIterator.java
@@ -32,10 +32,7 @@ public class AbsFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/CeilingFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/CeilingFunctionIterator.java
@@ -9,6 +9,7 @@ import sparksoniq.jsoniq.runtime.iterator.EmptySequenceIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.LocalFunctionCallIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import java.util.List;
 
@@ -20,27 +21,37 @@ public class CeilingFunctionIterator extends LocalFunctionCallIterator {
     @Override
     public Item next() {
         if (this._hasNext) {
-            RuntimeIterator iterator = this._children.get(0);
-            //TODO refactor empty items
-            if (iterator.getClass() == EmptySequenceIterator.class) {
-                return null;
-            }
-            else {
-                Item value = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
-                if (Item.isNumeric(value)) {
-                    Double result = Math.ceil(Item.getNumericValue(value, Double.class));
-                    this._hasNext = false;
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
-                }
-                else {
-                    throw new UnexpectedTypeException("Ceiling expression has non numeric args " +
-                            value.serialize(), getMetadata());
-                }
-            }
+            this._hasNext = false;
+            return result;
         } else
             throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " ceiling function", getMetadata());
     }
 
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
 
+        RuntimeIterator iterator = this._children.get(0);
+        if (iterator.getClass() == EmptySequenceIterator.class) {
+            this._hasNext = false;
+        }
+        else {
+            Item value = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
+            if (Item.isNumeric(value)) {
+                Double result = Math.ceil(Item.getNumericValue(value, Double.class));
+                this._hasNext = true;
+                this.result = new DoubleItem(result,
+                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+            }
+            else {
+                throw new UnexpectedTypeException("Ceiling expression has non numeric args " +
+                        value.serialize(), getMetadata());
+            }
+        }
+    }
+
+    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/CeilingFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/CeilingFunctionIterator.java
@@ -32,10 +32,7 @@ public class CeilingFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/CeilingFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/CeilingFunctionIterator.java
@@ -14,6 +14,9 @@ import sparksoniq.semantics.DynamicContext;
 import java.util.List;
 
 public class CeilingFunctionIterator extends LocalFunctionCallIterator {
+
+    private Item result;
+
     public CeilingFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, iteratorMetadata);
     }
@@ -23,8 +26,8 @@ public class CeilingFunctionIterator extends LocalFunctionCallIterator {
         if (this._hasNext) {
             this._hasNext = false;
             return result;
-        } else
-            throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " ceiling function", getMetadata());
+        }
+        throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " ceiling function", getMetadata());
     }
 
     @Override
@@ -37,21 +40,17 @@ public class CeilingFunctionIterator extends LocalFunctionCallIterator {
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {
             this._hasNext = false;
-        }
-        else {
+        } else {
             Item value = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
             if (Item.isNumeric(value)) {
                 Double result = Math.ceil(Item.getNumericValue(value, Double.class));
                 this._hasNext = true;
                 this.result = new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));
-            }
-            else {
+            } else {
                 throw new UnexpectedTypeException("Ceiling expression has non numeric args " +
                         value.serialize(), getMetadata());
             }
         }
     }
-
-    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/FloorFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/FloorFunctionIterator.java
@@ -14,6 +14,9 @@ import sparksoniq.semantics.DynamicContext;
 import java.util.List;
 
 public class FloorFunctionIterator extends LocalFunctionCallIterator {
+
+    private Item result;
+
     public FloorFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, iteratorMetadata);
     }
@@ -23,8 +26,8 @@ public class FloorFunctionIterator extends LocalFunctionCallIterator {
         if (this.hasNext()) {
             this._hasNext = false;
             return result;
-        } else
-            throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " floor function", getMetadata());
+        }
+        throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " floor function", getMetadata());
     }
 
     @Override
@@ -37,23 +40,17 @@ public class FloorFunctionIterator extends LocalFunctionCallIterator {
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {
             this._hasNext = false;
-        }
-        else {
+        } else {
             Item value = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
             if (Item.isNumeric(value)) {
                 Double result = Math.floor(Item.getNumericValue(value, Double.class));
                 this._hasNext = true;
                 this.result = new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));
-            }
-            else {
+            } else {
                 throw new UnexpectedTypeException("Floor expression has non numeric args " +
                         value.serialize(), getMetadata());
             }
         }
     }
-
-    Item result;
-
-
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/FloorFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/FloorFunctionIterator.java
@@ -32,10 +32,7 @@ public class FloorFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/FloorFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/FloorFunctionIterator.java
@@ -9,6 +9,7 @@ import sparksoniq.jsoniq.runtime.iterator.EmptySequenceIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.LocalFunctionCallIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import java.util.List;
 
@@ -19,28 +20,40 @@ public class FloorFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public Item next() {
-        if (this._hasNext) {
-            RuntimeIterator iterator = this._children.get(0);
-            //TODO refactor empty items
-            if (iterator.getClass() == EmptySequenceIterator.class) {
-                return null;
-            }
-            else {
-                Item value = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
-                if (Item.isNumeric(value)) {
-                    Double result = Math.floor(Item.getNumericValue(value, Double.class));
-                    this._hasNext = false;
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
-                }
-                else {
-                    throw new UnexpectedTypeException("Floor expression has non numeric args " +
-                            value.serialize(), getMetadata());
-                }
-            }
+        if (this.hasNext()) {
+            this._hasNext = false;
+            return result;
         } else
             throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " floor function", getMetadata());
     }
+
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
+
+        RuntimeIterator iterator = this._children.get(0);
+        if (iterator.getClass() == EmptySequenceIterator.class) {
+            this._hasNext = false;
+        }
+        else {
+            Item value = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
+            if (Item.isNumeric(value)) {
+                Double result = Math.floor(Item.getNumericValue(value, Double.class));
+                this._hasNext = true;
+                this.result = new DoubleItem(result,
+                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+            }
+            else {
+                throw new UnexpectedTypeException("Floor expression has non numeric args " +
+                        value.serialize(), getMetadata());
+            }
+        }
+    }
+
+    Item result;
 
 
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/PiFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/PiFunctionIterator.java
@@ -32,12 +32,9 @@ public class PiFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
+
+        this.result = new DoubleItem(Math.PI, ItemMetadata.fromIteratorMetadata(getMetadata()));
         this._hasNext = true;
-        this.result = new DoubleItem(Math.PI,
-                ItemMetadata.fromIteratorMetadata(getMetadata()));
     }
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/PiFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/PiFunctionIterator.java
@@ -9,6 +9,7 @@ import sparksoniq.jsoniq.runtime.iterator.EmptySequenceIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.LocalFunctionCallIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import java.util.List;
 
@@ -19,13 +20,23 @@ public class PiFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public Item next() {
-        if (this._hasNext) {
+        if (this.hasNext()) {
             this._hasNext = false;
-            return new DoubleItem(Math.PI,
-                    ItemMetadata.fromIteratorMetadata(getMetadata()));
+            return result;
         } else
             throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " pi function", getMetadata());
     }
 
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
+        this._hasNext = true;
+        this.result = new DoubleItem(Math.PI,
+                ItemMetadata.fromIteratorMetadata(getMetadata()));
+    }
 
+    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/PiFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/PiFunctionIterator.java
@@ -14,6 +14,9 @@ import sparksoniq.semantics.DynamicContext;
 import java.util.List;
 
 public class PiFunctionIterator extends LocalFunctionCallIterator {
+
+    private Item result;
+
     public PiFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, iteratorMetadata);
     }
@@ -23,8 +26,8 @@ public class PiFunctionIterator extends LocalFunctionCallIterator {
         if (this.hasNext()) {
             this._hasNext = false;
             return result;
-        } else
-            throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " pi function", getMetadata());
+        }
+        throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " pi function", getMetadata());
     }
 
     @Override
@@ -37,6 +40,4 @@ public class PiFunctionIterator extends LocalFunctionCallIterator {
         this.result = new DoubleItem(Math.PI,
                 ItemMetadata.fromIteratorMetadata(getMetadata()));
     }
-
-    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundFunctionIterator.java
@@ -35,10 +35,7 @@ public class RoundFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundFunctionIterator.java
@@ -10,6 +10,7 @@ import sparksoniq.jsoniq.runtime.iterator.EmptySequenceIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.LocalFunctionCallIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -22,41 +23,53 @@ public class RoundFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public Item next() {
-        if (this._hasNext) {
-            RuntimeIterator iterator = this._children.get(0);
-            //TODO refactor empty items
-            if (iterator.getClass() == EmptySequenceIterator.class) {
-                return null;
-            }
-            else {
-                Item value = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
-                Item precision;
-                if (this._children.size() > 1) {
-                    precision = this.getSingleItemOfTypeFromIterator(this._children.get(1), Item.class);
-                }
-                // if second param is not given precision is set as 0 (rounds to a whole number)
-                else {
-                    precision = new IntegerItem(0, ItemMetadata.fromIteratorMetadata(this.getMetadata()));
-                }
-                if (Item.isNumeric(value) && Item.isNumeric(precision)) {
-
-                    Double val = Item.getNumericValue(value, Double.class);
-                    Integer prec = Item.getNumericValue(precision, Integer.class);
-
-                    BigDecimal bd = new BigDecimal(val);
-                    bd = bd.setScale(prec, RoundingMode.HALF_UP);
-                    Double result = bd.doubleValue();
-
-                    this._hasNext = false;
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
-                }
-                else {
-                    throw new UnexpectedTypeException("Round expression has non numeric args " +
-                            value.serialize() + ", " + precision.serialize(), getMetadata());
-                }
-            }
+        if (this.hasNext()) {
+            this._hasNext = false;
+            return result;
         } else
             throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " round function", getMetadata());
     }
+
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
+
+        RuntimeIterator iterator = this._children.get(0);
+        if (iterator.getClass() == EmptySequenceIterator.class) {
+            this._hasNext = false;
+        }
+        else {
+            Item value = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
+            Item precision;
+            if (this._children.size() > 1) {
+                precision = this.getSingleItemOfTypeFromIterator(this._children.get(1), Item.class);
+            }
+            // if second param is not given precision is set as 0 (rounds to a whole number)
+            else {
+                precision = new IntegerItem(0, ItemMetadata.fromIteratorMetadata(this.getMetadata()));
+            }
+            if (Item.isNumeric(value) && Item.isNumeric(precision)) {
+
+                Double val = Item.getNumericValue(value, Double.class);
+                Integer prec = Item.getNumericValue(precision, Integer.class);
+
+                BigDecimal bd = new BigDecimal(val);
+                bd = bd.setScale(prec, RoundingMode.HALF_UP);
+                Double result = bd.doubleValue();
+
+                this._hasNext = true;
+                this.result =  new DoubleItem(result,
+                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+            }
+            else {
+                throw new UnexpectedTypeException("Round expression has non numeric args " +
+                        value.serialize() + ", " + precision.serialize(), getMetadata());
+            }
+        }
+    }
+
+    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundFunctionIterator.java
@@ -17,6 +17,9 @@ import java.math.RoundingMode;
 import java.util.List;
 
 public class RoundFunctionIterator extends LocalFunctionCallIterator {
+
+    private Item result;
+
     public RoundFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, iteratorMetadata);
     }
@@ -26,8 +29,8 @@ public class RoundFunctionIterator extends LocalFunctionCallIterator {
         if (this.hasNext()) {
             this._hasNext = false;
             return result;
-        } else
-            throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " round function", getMetadata());
+        }
+        throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " round function", getMetadata());
     }
 
     @Override
@@ -40,8 +43,7 @@ public class RoundFunctionIterator extends LocalFunctionCallIterator {
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {
             this._hasNext = false;
-        }
-        else {
+        } else {
             Item value = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
             Item precision;
             if (this._children.size() > 1) {
@@ -61,15 +63,12 @@ public class RoundFunctionIterator extends LocalFunctionCallIterator {
                 Double result = bd.doubleValue();
 
                 this._hasNext = true;
-                this.result =  new DoubleItem(result,
+                this.result = new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));
-            }
-            else {
+            } else {
                 throw new UnexpectedTypeException("Round expression has non numeric args " +
                         value.serialize() + ", " + precision.serialize(), getMetadata());
             }
         }
     }
-
-    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundHalfToEvenFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundHalfToEvenFunctionIterator.java
@@ -10,6 +10,7 @@ import sparksoniq.jsoniq.runtime.iterator.EmptySequenceIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.LocalFunctionCallIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -22,43 +23,55 @@ public class RoundHalfToEvenFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public Item next() {
-        if (this._hasNext) {
-            RuntimeIterator iterator = this._children.get(0);
-            //TODO refactor empty items
-            if (iterator.getClass() == EmptySequenceIterator.class) {
-                return null;
-            }
-            else {
-                Item value = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
-                Item precision;
-                if (this._children.size() > 1) {
-                    precision = this.getSingleItemOfTypeFromIterator(this._children.get(1), Item.class);
-                }
-                // if second param is not given precision is set as 0 (rounds to a whole number)
-                else {
-                    precision = new IntegerItem(0, ItemMetadata.fromIteratorMetadata(this.getMetadata()));
-                }
-                if (Item.isNumeric(value) && Item.isNumeric(precision)) {
-
-                    Double val = Item.getNumericValue(value, Double.class);
-                    Integer prec = Item.getNumericValue(precision, Integer.class);
-
-                    BigDecimal bd = new BigDecimal(val);
-                    bd = bd.setScale(prec, RoundingMode.HALF_EVEN);
-                    Double result = bd.doubleValue();
-
-                    this._hasNext = false;
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
-                }
-                else {
-                    throw new UnexpectedTypeException("Round-half-to-even expression has non numeric args " +
-                            value.serialize() + ", " + precision.serialize(), getMetadata());
-                }
-            }
+        if (this.hasNext()) {
+            this._hasNext = false;
+            return result;
         } else
             throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " round-half-to-even function", getMetadata());
     }
+
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
+
+        RuntimeIterator iterator = this._children.get(0);
+        if (iterator.getClass() == EmptySequenceIterator.class) {
+            this._hasNext = true;
+        }
+        else {
+            Item value = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
+            Item precision;
+            if (this._children.size() > 1) {
+                precision = this.getSingleItemOfTypeFromIterator(this._children.get(1), Item.class);
+            }
+            // if second param is not given precision is set as 0 (rounds to a whole number)
+            else {
+                precision = new IntegerItem(0, ItemMetadata.fromIteratorMetadata(this.getMetadata()));
+            }
+            if (Item.isNumeric(value) && Item.isNumeric(precision)) {
+
+                Double val = Item.getNumericValue(value, Double.class);
+                Integer prec = Item.getNumericValue(precision, Integer.class);
+
+                BigDecimal bd = new BigDecimal(val);
+                bd = bd.setScale(prec, RoundingMode.HALF_EVEN);
+                Double result = bd.doubleValue();
+
+                this._hasNext = true;
+                this.result = new DoubleItem(result,
+                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+            }
+            else {
+                throw new UnexpectedTypeException("Round-half-to-even expression has non numeric args " +
+                        value.serialize() + ", " + precision.serialize(), getMetadata());
+            }
+        }
+    }
+
+    Item result;
 
 
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundHalfToEvenFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundHalfToEvenFunctionIterator.java
@@ -17,6 +17,9 @@ import java.math.RoundingMode;
 import java.util.List;
 
 public class RoundHalfToEvenFunctionIterator extends LocalFunctionCallIterator {
+
+    private Item result;
+
     public RoundHalfToEvenFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, iteratorMetadata);
     }
@@ -26,8 +29,8 @@ public class RoundHalfToEvenFunctionIterator extends LocalFunctionCallIterator {
         if (this.hasNext()) {
             this._hasNext = false;
             return result;
-        } else
-            throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " round-half-to-even function", getMetadata());
+        }
+        throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " round-half-to-even function", getMetadata());
     }
 
     @Override
@@ -40,8 +43,7 @@ public class RoundHalfToEvenFunctionIterator extends LocalFunctionCallIterator {
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {
             this._hasNext = true;
-        }
-        else {
+        } else {
             Item value = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
             Item precision;
             if (this._children.size() > 1) {
@@ -63,15 +65,10 @@ public class RoundHalfToEvenFunctionIterator extends LocalFunctionCallIterator {
                 this._hasNext = true;
                 this.result = new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));
-            }
-            else {
+            } else {
                 throw new UnexpectedTypeException("Round-half-to-even expression has non numeric args " +
                         value.serialize() + ", " + precision.serialize(), getMetadata());
             }
         }
     }
-
-    Item result;
-
-
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundHalfToEvenFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundHalfToEvenFunctionIterator.java
@@ -35,10 +35,7 @@ public class RoundHalfToEvenFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Exp10FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Exp10FunctionIterator.java
@@ -9,6 +9,7 @@ import sparksoniq.jsoniq.runtime.iterator.EmptySequenceIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.LocalFunctionCallIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import java.util.List;
 
@@ -19,28 +20,38 @@ public class Exp10FunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public Item next() {
-        if (this._hasNext) {
-            RuntimeIterator iterator = this._children.get(0);
-            //TODO refactor empty items
-            if (iterator.getClass() == EmptySequenceIterator.class) {
-                return null;
-            }
-            else {
-                Item exponent = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
-                if (Item.isNumeric(exponent)) {
-                    Double result = Math.pow(10.0, Item.getNumericValue(exponent, Double.class));
-                    this._hasNext = false;
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
-                }
-                else {
-                    throw new UnexpectedTypeException("Exp10 expression has non numeric args " +
-                            exponent.serialize(), getMetadata());
-                }
-            }
+        if (this.hasNext()) {
+            this._hasNext = false;
+            return result;
         } else
             throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " exp10 function", getMetadata());
     }
 
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
 
+        RuntimeIterator iterator = this._children.get(0);
+        if (iterator.getClass() == EmptySequenceIterator.class) {
+            this._hasNext = false;
+        }
+        else {
+            Item exponent = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
+            if (Item.isNumeric(exponent)) {
+                Double result = Math.pow(10.0, Item.getNumericValue(exponent, Double.class));
+                this._hasNext = true;
+                this.result = new DoubleItem(result,
+                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+            }
+            else {
+                throw new UnexpectedTypeException("Exp10 expression has non numeric args " +
+                        exponent.serialize(), getMetadata());
+            }
+        }
+    }
+
+    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Exp10FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Exp10FunctionIterator.java
@@ -14,6 +14,9 @@ import sparksoniq.semantics.DynamicContext;
 import java.util.List;
 
 public class Exp10FunctionIterator extends LocalFunctionCallIterator {
+
+    private Item result;
+
     public Exp10FunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, iteratorMetadata);
     }
@@ -23,8 +26,8 @@ public class Exp10FunctionIterator extends LocalFunctionCallIterator {
         if (this.hasNext()) {
             this._hasNext = false;
             return result;
-        } else
-            throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " exp10 function", getMetadata());
+        }
+        throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " exp10 function", getMetadata());
     }
 
     @Override
@@ -37,21 +40,17 @@ public class Exp10FunctionIterator extends LocalFunctionCallIterator {
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {
             this._hasNext = false;
-        }
-        else {
+        } else {
             Item exponent = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
             if (Item.isNumeric(exponent)) {
                 Double result = Math.pow(10.0, Item.getNumericValue(exponent, Double.class));
                 this._hasNext = true;
                 this.result = new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));
-            }
-            else {
+            } else {
                 throw new UnexpectedTypeException("Exp10 expression has non numeric args " +
                         exponent.serialize(), getMetadata());
             }
         }
     }
-
-    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Exp10FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Exp10FunctionIterator.java
@@ -32,10 +32,7 @@ public class Exp10FunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/ExpFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/ExpFunctionIterator.java
@@ -32,10 +32,7 @@ public class ExpFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/ExpFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/ExpFunctionIterator.java
@@ -14,6 +14,9 @@ import sparksoniq.semantics.DynamicContext;
 import java.util.List;
 
 public class ExpFunctionIterator extends LocalFunctionCallIterator {
+
+    private Item result;
+
     public ExpFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, iteratorMetadata);
     }
@@ -23,8 +26,8 @@ public class ExpFunctionIterator extends LocalFunctionCallIterator {
         if (this.hasNext()) {
             this._hasNext = false;
             return result;
-        } else
-            throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " exp function", getMetadata());
+        }
+        throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " exp function", getMetadata());
     }
 
     @Override
@@ -37,21 +40,17 @@ public class ExpFunctionIterator extends LocalFunctionCallIterator {
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {
             this._hasNext = false;
-        }
-        else {
+        } else {
             Item exponent = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
             if (Item.isNumeric(exponent)) {
                 Double result = Math.exp(Item.getNumericValue(exponent, Double.class));
                 this._hasNext = true;
                 this.result = new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));
-            }
-            else {
+            } else {
                 throw new UnexpectedTypeException("Exp expression has non numeric args " +
                         exponent.serialize(), getMetadata());
             }
         }
     }
-
-    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Log10FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Log10FunctionIterator.java
@@ -32,10 +32,7 @@ public class Log10FunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Log10FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Log10FunctionIterator.java
@@ -14,6 +14,9 @@ import sparksoniq.semantics.DynamicContext;
 import java.util.List;
 
 public class Log10FunctionIterator extends LocalFunctionCallIterator {
+
+    private Item result;
+
     public Log10FunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, iteratorMetadata);
     }
@@ -23,8 +26,8 @@ public class Log10FunctionIterator extends LocalFunctionCallIterator {
         if (this.hasNext()) {
             this._hasNext = false;
             return result;
-        } else
-            throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " log10 function", getMetadata());
+        }
+        throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " log10 function", getMetadata());
     }
 
     @Override
@@ -37,21 +40,17 @@ public class Log10FunctionIterator extends LocalFunctionCallIterator {
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {
             this._hasNext = false;
-        }
-        else {
+        } else {
             Item value = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
             if (Item.isNumeric(value)) {
                 Double result = Math.log10(Item.getNumericValue(value, Double.class));
                 this._hasNext = true;
                 this.result = new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));
-            }
-            else {
+            } else {
                 throw new UnexpectedTypeException("Log10 expression has non numeric args " +
                         value.serialize(), getMetadata());
             }
         }
     }
-
-    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Log10FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Log10FunctionIterator.java
@@ -9,6 +9,7 @@ import sparksoniq.jsoniq.runtime.iterator.EmptySequenceIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.LocalFunctionCallIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import java.util.List;
 
@@ -19,28 +20,38 @@ public class Log10FunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public Item next() {
-        if (this._hasNext) {
-            RuntimeIterator iterator = this._children.get(0);
-            //TODO refactor empty items
-            if (iterator.getClass() == EmptySequenceIterator.class) {
-                return null;
-            }
-            else {
-                Item value = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
-                if (Item.isNumeric(value)) {
-                    Double result = Math.log10(Item.getNumericValue(value, Double.class));
-                    this._hasNext = false;
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
-                }
-                else {
-                    throw new UnexpectedTypeException("Log10 expression has non numeric args " +
-                            value.serialize(), getMetadata());
-                }
-            }
+        if (this.hasNext()) {
+            this._hasNext = false;
+            return result;
         } else
             throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " log10 function", getMetadata());
     }
 
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
 
+        RuntimeIterator iterator = this._children.get(0);
+        if (iterator.getClass() == EmptySequenceIterator.class) {
+            this._hasNext = false;
+        }
+        else {
+            Item value = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
+            if (Item.isNumeric(value)) {
+                Double result = Math.log10(Item.getNumericValue(value, Double.class));
+                this._hasNext = true;
+                this.result = new DoubleItem(result,
+                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+            }
+            else {
+                throw new UnexpectedTypeException("Log10 expression has non numeric args " +
+                        value.serialize(), getMetadata());
+            }
+        }
+    }
+
+    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/LogFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/LogFunctionIterator.java
@@ -9,6 +9,7 @@ import sparksoniq.jsoniq.runtime.iterator.EmptySequenceIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.LocalFunctionCallIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import java.util.List;
 
@@ -19,28 +20,38 @@ public class LogFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public Item next() {
-        if (this._hasNext) {
-            RuntimeIterator iterator = this._children.get(0);
-            //TODO refactor empty items
-            if (iterator.getClass() == EmptySequenceIterator.class) {
-                return null;
-            }
-            else {
-                Item value = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
-                if (Item.isNumeric(value)) {
-                    Double result = Math.log(Item.getNumericValue(value, Double.class));
-                    this._hasNext = false;
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
-                }
-                else {
-                    throw new UnexpectedTypeException("Log expression has non numeric args " +
-                            value.serialize(), getMetadata());
-                }
-            }
+        if (this.hasNext()) {
+            this._hasNext = false;
+            return result;
         } else
             throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " log function", getMetadata());
     }
 
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
 
+        RuntimeIterator iterator = this._children.get(0);
+        if (iterator.getClass() == EmptySequenceIterator.class) {
+            this._hasNext = false;
+        }
+        else {
+            Item value = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
+            if (Item.isNumeric(value)) {
+                Double result = Math.log(Item.getNumericValue(value, Double.class));
+                this._hasNext = true;
+                this.result = new DoubleItem(result,
+                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+            }
+            else {
+                throw new UnexpectedTypeException("Log expression has non numeric args " +
+                        value.serialize(), getMetadata());
+            }
+        }
+    }
+
+    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/LogFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/LogFunctionIterator.java
@@ -32,10 +32,7 @@ public class LogFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/LogFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/LogFunctionIterator.java
@@ -14,6 +14,9 @@ import sparksoniq.semantics.DynamicContext;
 import java.util.List;
 
 public class LogFunctionIterator extends LocalFunctionCallIterator {
+
+    private Item result;
+
     public LogFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, iteratorMetadata);
     }
@@ -23,8 +26,8 @@ public class LogFunctionIterator extends LocalFunctionCallIterator {
         if (this.hasNext()) {
             this._hasNext = false;
             return result;
-        } else
-            throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " log function", getMetadata());
+        }
+        throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " log function", getMetadata());
     }
 
     @Override
@@ -37,21 +40,17 @@ public class LogFunctionIterator extends LocalFunctionCallIterator {
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {
             this._hasNext = false;
-        }
-        else {
+        } else {
             Item value = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
             if (Item.isNumeric(value)) {
                 Double result = Math.log(Item.getNumericValue(value, Double.class));
                 this._hasNext = true;
                 this.result = new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));
-            }
-            else {
+            } else {
                 throw new UnexpectedTypeException("Log expression has non numeric args " +
                         value.serialize(), getMetadata());
             }
         }
     }
-
-    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/PowFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/PowFunctionIterator.java
@@ -32,10 +32,7 @@ public class PowFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/PowFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/PowFunctionIterator.java
@@ -14,6 +14,9 @@ import sparksoniq.semantics.DynamicContext;
 import java.util.List;
 
 public class PowFunctionIterator extends LocalFunctionCallIterator {
+
+    private Item result;
+
     public PowFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, iteratorMetadata);
     }
@@ -23,8 +26,8 @@ public class PowFunctionIterator extends LocalFunctionCallIterator {
         if (this.hasNext()) {
             this._hasNext = false;
             return result;
-        } else
-            throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " pow function", getMetadata());
+        }
+        throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " pow function", getMetadata());
     }
 
     @Override
@@ -37,8 +40,7 @@ public class PowFunctionIterator extends LocalFunctionCallIterator {
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {
             this._hasNext = false;
-        }
-        else {
+        } else {
             Item base = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
             Item exponent = this.getSingleItemOfTypeFromIterator(this._children.get(1), Item.class);
             if (Item.isNumeric(base) && Item.isNumeric(exponent)) {
@@ -47,13 +49,10 @@ public class PowFunctionIterator extends LocalFunctionCallIterator {
                 this._hasNext = true;
                 this.result = new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));
-            }
-            else {
+            } else {
                 throw new UnexpectedTypeException("Pow expression has non numeric args " +
                         base.serialize() + ", " + exponent.serialize(), getMetadata());
             }
         }
     }
-
-    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/PowFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/PowFunctionIterator.java
@@ -9,6 +9,7 @@ import sparksoniq.jsoniq.runtime.iterator.EmptySequenceIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.LocalFunctionCallIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import java.util.List;
 
@@ -19,30 +20,40 @@ public class PowFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public Item next() {
-        if (this._hasNext) {
-            RuntimeIterator iterator = this._children.get(0);
-            //TODO refactor empty items
-            if (iterator.getClass() == EmptySequenceIterator.class) {
-                return null;
-            }
-            else {
-                Item base = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
-                Item exponent = this.getSingleItemOfTypeFromIterator(this._children.get(1), Item.class);
-                if (Item.isNumeric(base) && Item.isNumeric(exponent)) {
-                    Double result = Math.pow(Item.getNumericValue(base, Double.class)
-                            , Item.getNumericValue(exponent, Double.class));
-                    this._hasNext = false;
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
-                }
-                else {
-                    throw new UnexpectedTypeException("Pow expression has non numeric args " +
-                            base.serialize() + ", " + exponent.serialize(), getMetadata());
-                }
-            }
+        if (this.hasNext()) {
+            this._hasNext = false;
+            return result;
         } else
             throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " pow function", getMetadata());
     }
 
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
 
+        RuntimeIterator iterator = this._children.get(0);
+        if (iterator.getClass() == EmptySequenceIterator.class) {
+            this._hasNext = false;
+        }
+        else {
+            Item base = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
+            Item exponent = this.getSingleItemOfTypeFromIterator(this._children.get(1), Item.class);
+            if (Item.isNumeric(base) && Item.isNumeric(exponent)) {
+                Double result = Math.pow(Item.getNumericValue(base, Double.class)
+                        , Item.getNumericValue(exponent, Double.class));
+                this._hasNext = true;
+                this.result = new DoubleItem(result,
+                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+            }
+            else {
+                throw new UnexpectedTypeException("Pow expression has non numeric args " +
+                        base.serialize() + ", " + exponent.serialize(), getMetadata());
+            }
+        }
+    }
+
+    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/SqrtFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/SqrtFunctionIterator.java
@@ -14,6 +14,9 @@ import sparksoniq.semantics.DynamicContext;
 import java.util.List;
 
 public class SqrtFunctionIterator extends LocalFunctionCallIterator {
+
+    private Item result;
+
     public SqrtFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, iteratorMetadata);
     }
@@ -23,8 +26,8 @@ public class SqrtFunctionIterator extends LocalFunctionCallIterator {
         if (this.hasNext()) {
             this._hasNext = false;
             return result;
-        } else
-            throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " sqrt function", getMetadata());
+        }
+        throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " sqrt function", getMetadata());
     }
 
     @Override
@@ -37,21 +40,17 @@ public class SqrtFunctionIterator extends LocalFunctionCallIterator {
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {
             this._hasNext = false;
-        }
-        else {
+        } else {
             Item value = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
             if (Item.isNumeric(value)) {
                 Double result = Math.sqrt(Item.getNumericValue(value, Double.class));
                 this._hasNext = true;
                 this.result = new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));
-            }
-            else {
+            } else {
                 throw new UnexpectedTypeException("Sqrt expression has non numeric args " +
                         value.serialize(), getMetadata());
             }
         }
     }
-
-    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/SqrtFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/SqrtFunctionIterator.java
@@ -32,10 +32,7 @@ public class SqrtFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/SqrtFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/SqrtFunctionIterator.java
@@ -9,6 +9,7 @@ import sparksoniq.jsoniq.runtime.iterator.EmptySequenceIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.LocalFunctionCallIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import java.util.List;
 
@@ -19,28 +20,38 @@ public class SqrtFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public Item next() {
-        if (this._hasNext) {
-            RuntimeIterator iterator = this._children.get(0);
-            //TODO refactor empty items
-            if (iterator.getClass() == EmptySequenceIterator.class) {
-                return null;
-            }
-            else {
-                Item value = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
-                if (Item.isNumeric(value)) {
-                    Double result = Math.sqrt(Item.getNumericValue(value, Double.class));
-                    this._hasNext = false;
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
-                }
-                else {
-                    throw new UnexpectedTypeException("Sqrt expression has non numeric args " +
-                            value.serialize(), getMetadata());
-                }
-            }
+        if (this.hasNext()) {
+            this._hasNext = false;
+            return result;
         } else
             throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " sqrt function", getMetadata());
     }
 
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
 
+        RuntimeIterator iterator = this._children.get(0);
+        if (iterator.getClass() == EmptySequenceIterator.class) {
+            this._hasNext = false;
+        }
+        else {
+            Item value = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
+            if (Item.isNumeric(value)) {
+                Double result = Math.sqrt(Item.getNumericValue(value, Double.class));
+                this._hasNext = true;
+                this.result = new DoubleItem(result,
+                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+            }
+            else {
+                throw new UnexpectedTypeException("Sqrt expression has non numeric args " +
+                        value.serialize(), getMetadata());
+            }
+        }
+    }
+
+    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ACosFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ACosFunctionIterator.java
@@ -9,6 +9,7 @@ import sparksoniq.jsoniq.runtime.iterator.EmptySequenceIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.LocalFunctionCallIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import java.util.List;
 
@@ -19,28 +20,38 @@ public class ACosFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public Item next() {
-        if (this._hasNext) {
-            RuntimeIterator iterator = this._children.get(0);
-            //TODO refactor empty items
-            if (iterator.getClass() == EmptySequenceIterator.class) {
-                return null;
-            }
-            else {
-                Item radians = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
-                if (Item.isNumeric(radians)) {
-                    Double result = Math.acos(Item.getNumericValue(radians, Double.class));
-                    this._hasNext = false;
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
-                }
-                else {
-                    throw new UnexpectedTypeException("ACos expression has non numeric args " +
-                            radians.serialize(), getMetadata());
-                }
-            }
+        if (this.hasNext()) {
+            this._hasNext = false;
+            return result;
         } else
             throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " acos function", getMetadata());
     }
 
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
 
+        RuntimeIterator iterator = this._children.get(0);
+        if (iterator.getClass() == EmptySequenceIterator.class) {
+            this._hasNext = false;
+        }
+        else {
+            Item radians = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
+            if (Item.isNumeric(radians)) {
+                Double result = Math.acos(Item.getNumericValue(radians, Double.class));
+                this._hasNext = true;
+                this.result = new DoubleItem(result,
+                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+            }
+            else {
+                throw new UnexpectedTypeException("ACos expression has non numeric args " +
+                        radians.serialize(), getMetadata());
+            }
+        }
+    }
+
+    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ACosFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ACosFunctionIterator.java
@@ -32,10 +32,7 @@ public class ACosFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ACosFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ACosFunctionIterator.java
@@ -14,6 +14,9 @@ import sparksoniq.semantics.DynamicContext;
 import java.util.List;
 
 public class ACosFunctionIterator extends LocalFunctionCallIterator {
+
+    private Item result;
+
     public ACosFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, iteratorMetadata);
     }
@@ -23,8 +26,8 @@ public class ACosFunctionIterator extends LocalFunctionCallIterator {
         if (this.hasNext()) {
             this._hasNext = false;
             return result;
-        } else
-            throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " acos function", getMetadata());
+        }
+        throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " acos function", getMetadata());
     }
 
     @Override
@@ -37,21 +40,17 @@ public class ACosFunctionIterator extends LocalFunctionCallIterator {
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {
             this._hasNext = false;
-        }
-        else {
+        } else {
             Item radians = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
             if (Item.isNumeric(radians)) {
                 Double result = Math.acos(Item.getNumericValue(radians, Double.class));
                 this._hasNext = true;
                 this.result = new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));
-            }
-            else {
+            } else {
                 throw new UnexpectedTypeException("ACos expression has non numeric args " +
                         radians.serialize(), getMetadata());
             }
         }
     }
-
-    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ASinFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ASinFunctionIterator.java
@@ -32,10 +32,7 @@ public class ASinFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ASinFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ASinFunctionIterator.java
@@ -14,6 +14,9 @@ import sparksoniq.semantics.DynamicContext;
 import java.util.List;
 
 public class ASinFunctionIterator extends LocalFunctionCallIterator {
+
+    private Item result;
+
     public ASinFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, iteratorMetadata);
     }
@@ -23,8 +26,8 @@ public class ASinFunctionIterator extends LocalFunctionCallIterator {
         if (this.hasNext()) {
             this._hasNext = false;
             return result;
-        } else
-            throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " asin function", getMetadata());
+        }
+        throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " asin function", getMetadata());
     }
 
     @Override
@@ -37,21 +40,17 @@ public class ASinFunctionIterator extends LocalFunctionCallIterator {
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {
             this._hasNext = false;
-        }
-        else {
+        } else {
             Item radians = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
             if (Item.isNumeric(radians)) {
                 Double result = Math.asin(Item.getNumericValue(radians, Double.class));
                 this._hasNext = true;
                 this.result = new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));
-            }
-            else {
+            } else {
                 throw new UnexpectedTypeException("ASin expression has non numeric args " +
                         radians.serialize(), getMetadata());
             }
         }
     }
-
-    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ASinFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ASinFunctionIterator.java
@@ -9,6 +9,7 @@ import sparksoniq.jsoniq.runtime.iterator.EmptySequenceIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.LocalFunctionCallIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import java.util.List;
 
@@ -19,28 +20,38 @@ public class ASinFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public Item next() {
-        if (this._hasNext) {
-            RuntimeIterator iterator = this._children.get(0);
-            //TODO refactor empty items
-            if (iterator.getClass() == EmptySequenceIterator.class) {
-                return null;
-            }
-            else {
-                Item radians = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
-                if (Item.isNumeric(radians)) {
-                    Double result = Math.asin(Item.getNumericValue(radians, Double.class));
-                    this._hasNext = false;
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
-                }
-                else {
-                    throw new UnexpectedTypeException("ASin expression has non numeric args " +
-                            radians.serialize(), getMetadata());
-                }
-            }
+        if (this.hasNext()) {
+            this._hasNext = false;
+            return result;
         } else
             throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " asin function", getMetadata());
     }
 
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
 
+        RuntimeIterator iterator = this._children.get(0);
+        if (iterator.getClass() == EmptySequenceIterator.class) {
+            this._hasNext = false;
+        }
+        else {
+            Item radians = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
+            if (Item.isNumeric(radians)) {
+                Double result = Math.asin(Item.getNumericValue(radians, Double.class));
+                this._hasNext = true;
+                this.result = new DoubleItem(result,
+                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+            }
+            else {
+                throw new UnexpectedTypeException("ASin expression has non numeric args " +
+                        radians.serialize(), getMetadata());
+            }
+        }
+    }
+
+    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATan2FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATan2FunctionIterator.java
@@ -14,6 +14,9 @@ import sparksoniq.semantics.DynamicContext;
 import java.util.List;
 
 public class ATan2FunctionIterator extends LocalFunctionCallIterator {
+
+    private Item result;
+
     public ATan2FunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, iteratorMetadata);
     }
@@ -23,8 +26,8 @@ public class ATan2FunctionIterator extends LocalFunctionCallIterator {
         if (this.hasNext()) {
             this._hasNext = false;
             return result;
-        } else
-            throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " atan2 function", getMetadata());
+        }
+        throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " atan2 function", getMetadata());
     }
 
     @Override
@@ -42,13 +45,10 @@ public class ATan2FunctionIterator extends LocalFunctionCallIterator {
             this._hasNext = true;
             this.result = new DoubleItem(result,
                     ItemMetadata.fromIteratorMetadata(getMetadata()));
-        }
-        else {
+        } else {
             throw new UnexpectedTypeException("ATan2 expression has non numeric args " +
                     y.serialize() + ", " + x.serialize(), getMetadata());
 
         }
     }
-
-    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATan2FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATan2FunctionIterator.java
@@ -9,6 +9,7 @@ import sparksoniq.jsoniq.runtime.iterator.EmptySequenceIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.LocalFunctionCallIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import java.util.List;
 
@@ -19,24 +20,35 @@ public class ATan2FunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public Item next() {
-        if (this._hasNext) {
-            Item y = this.getSingleItemOfTypeFromIterator(this._children.get(0), Item.class);
-            Item x = this.getSingleItemOfTypeFromIterator(this._children.get(1), Item.class);
-            if (Item.isNumeric(y) && Item.isNumeric(x)) {
-                Double result = Math.atan2(Item.getNumericValue(y, Double.class)
-                        , Item.getNumericValue(x, Double.class));
-                this._hasNext = false;
-                return new DoubleItem(result,
-                        ItemMetadata.fromIteratorMetadata(getMetadata()));
-            }
-            else {
-                throw new UnexpectedTypeException("ATan2 expression has non numeric args " +
-                        y.serialize() + ", " + x.serialize(), getMetadata());
-
-            }
+        if (this.hasNext()) {
+            this._hasNext = false;
+            return result;
         } else
             throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " atan2 function", getMetadata());
     }
 
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
 
+        Item y = this.getSingleItemOfTypeFromIterator(this._children.get(0), Item.class);
+        Item x = this.getSingleItemOfTypeFromIterator(this._children.get(1), Item.class);
+        if (Item.isNumeric(y) && Item.isNumeric(x)) {
+            Double result = Math.atan2(Item.getNumericValue(y, Double.class)
+                    , Item.getNumericValue(x, Double.class));
+            this._hasNext = true;
+            this.result = new DoubleItem(result,
+                    ItemMetadata.fromIteratorMetadata(getMetadata()));
+        }
+        else {
+            throw new UnexpectedTypeException("ATan2 expression has non numeric args " +
+                    y.serialize() + ", " + x.serialize(), getMetadata());
+
+        }
+    }
+
+    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATan2FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATan2FunctionIterator.java
@@ -32,10 +32,7 @@ public class ATan2FunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         Item y = this.getSingleItemOfTypeFromIterator(this._children.get(0), Item.class);
         Item x = this.getSingleItemOfTypeFromIterator(this._children.get(1), Item.class);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATanFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATanFunctionIterator.java
@@ -9,6 +9,7 @@ import sparksoniq.jsoniq.runtime.iterator.EmptySequenceIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.LocalFunctionCallIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import java.util.List;
 
@@ -19,28 +20,38 @@ public class ATanFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public Item next() {
-        if (this._hasNext) {
-            RuntimeIterator iterator = this._children.get(0);
-            //TODO refactor empty items
-            if (iterator.getClass() == EmptySequenceIterator.class) {
-                return null;
-            }
-            else {
-                Item radians = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
-                if (Item.isNumeric(radians)) {
-                    Double result = Math.atan(Item.getNumericValue(radians, Double.class));
-                    this._hasNext = false;
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
-                }
-                else {
-                    throw new UnexpectedTypeException("ATan expression has non numeric args " +
-                            radians.serialize(), getMetadata());
-                }
-            }
+        if (this.hasNext()) {
+            this._hasNext = false;
+            return result;
         } else
             throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " atan function", getMetadata());
     }
 
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
 
+        RuntimeIterator iterator = this._children.get(0);
+        if (iterator.getClass() == EmptySequenceIterator.class) {
+            this._hasNext = false;
+        }
+        else {
+            Item radians = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
+            if (Item.isNumeric(radians)) {
+                Double result = Math.atan(Item.getNumericValue(radians, Double.class));
+                this._hasNext = true;
+                this.result = new DoubleItem(result,
+                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+            }
+            else {
+                throw new UnexpectedTypeException("ATan expression has non numeric args " +
+                        radians.serialize(), getMetadata());
+            }
+        }
+    }
+
+    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATanFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATanFunctionIterator.java
@@ -32,10 +32,7 @@ public class ATanFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATanFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATanFunctionIterator.java
@@ -14,6 +14,9 @@ import sparksoniq.semantics.DynamicContext;
 import java.util.List;
 
 public class ATanFunctionIterator extends LocalFunctionCallIterator {
+
+    private Item result;
+
     public ATanFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, iteratorMetadata);
     }
@@ -23,8 +26,8 @@ public class ATanFunctionIterator extends LocalFunctionCallIterator {
         if (this.hasNext()) {
             this._hasNext = false;
             return result;
-        } else
-            throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " atan function", getMetadata());
+        }
+        throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " atan function", getMetadata());
     }
 
     @Override
@@ -37,21 +40,17 @@ public class ATanFunctionIterator extends LocalFunctionCallIterator {
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {
             this._hasNext = false;
-        }
-        else {
+        } else {
             Item radians = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
             if (Item.isNumeric(radians)) {
                 Double result = Math.atan(Item.getNumericValue(radians, Double.class));
                 this._hasNext = true;
                 this.result = new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));
-            }
-            else {
+            } else {
                 throw new UnexpectedTypeException("ATan expression has non numeric args " +
                         radians.serialize(), getMetadata());
             }
         }
     }
-
-    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/CosFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/CosFunctionIterator.java
@@ -33,10 +33,7 @@ public class CosFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/CosFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/CosFunctionIterator.java
@@ -15,6 +15,9 @@ import java.util.List;
 import java.lang.Math;
 
 public class CosFunctionIterator extends LocalFunctionCallIterator {
+
+    private Item result;
+
     public CosFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, iteratorMetadata);
     }
@@ -24,8 +27,8 @@ public class CosFunctionIterator extends LocalFunctionCallIterator {
         if (this.hasNext()) {
             this._hasNext = false;
             return result;
-        } else
-            throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " cos function", getMetadata());
+        }
+        throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " cos function", getMetadata());
     }
 
     @Override
@@ -38,21 +41,17 @@ public class CosFunctionIterator extends LocalFunctionCallIterator {
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {
             this._hasNext = false;
-        }
-        else {
+        } else {
             Item radians = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
             if (Item.isNumeric(radians)) {
                 Double result = Math.cos(Item.getNumericValue(radians, Double.class));
                 this._hasNext = true;
                 this.result = new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));
-            }
-            else {
+            } else {
                 throw new UnexpectedTypeException("Cos expression has non numeric args " +
                         radians.serialize(), getMetadata());
             }
         }
     }
-
-    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/CosFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/CosFunctionIterator.java
@@ -9,6 +9,7 @@ import sparksoniq.jsoniq.runtime.iterator.EmptySequenceIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.LocalFunctionCallIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import java.util.List;
 import java.lang.Math;
@@ -20,28 +21,38 @@ public class CosFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public Item next() {
-        if (this._hasNext) {
-            RuntimeIterator iterator = this._children.get(0);
-            //TODO refactor empty items
-            if (iterator.getClass() == EmptySequenceIterator.class) {
-                return null;
-            }
-            else {
-                Item radians = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
-                if (Item.isNumeric(radians)) {
-                    Double result = Math.cos(Item.getNumericValue(radians, Double.class));
-                    this._hasNext = false;
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
-                }
-                else {
-                    throw new UnexpectedTypeException("Cos expression has non numeric args " +
-                            radians.serialize(), getMetadata());
-                }
-            }
+        if (this.hasNext()) {
+            this._hasNext = false;
+            return result;
         } else
             throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " cos function", getMetadata());
     }
 
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
 
+        RuntimeIterator iterator = this._children.get(0);
+        if (iterator.getClass() == EmptySequenceIterator.class) {
+            this._hasNext = false;
+        }
+        else {
+            Item radians = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
+            if (Item.isNumeric(radians)) {
+                Double result = Math.cos(Item.getNumericValue(radians, Double.class));
+                this._hasNext = true;
+                this.result = new DoubleItem(result,
+                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+            }
+            else {
+                throw new UnexpectedTypeException("Cos expression has non numeric args " +
+                        radians.serialize(), getMetadata());
+            }
+        }
+    }
+
+    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/SinFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/SinFunctionIterator.java
@@ -9,6 +9,7 @@ import sparksoniq.jsoniq.runtime.iterator.EmptySequenceIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.LocalFunctionCallIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import java.util.List;
 
@@ -19,28 +20,38 @@ public class SinFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public Item next() {
-        if (this._hasNext) {
-            RuntimeIterator iterator = this._children.get(0);
-            //TODO refactor empty items
-            if (iterator.getClass() == EmptySequenceIterator.class) {
-                return null;
-            }
-            else {
-                Item radians = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
-                if (Item.isNumeric(radians)) {
-                    Double result = Math.sin(Item.getNumericValue(radians, Double.class));
-                    this._hasNext = false;
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
-                }
-                else {
-                    throw new UnexpectedTypeException("Sin expression has non numeric args " +
-                            radians.serialize(), getMetadata());
-                }
-            }
+        if (this.hasNext()) {
+            this._hasNext = false;
+            return result;
         } else
             throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " sin function", getMetadata());
     }
 
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
 
+        RuntimeIterator iterator = this._children.get(0);
+        if (iterator.getClass() == EmptySequenceIterator.class) {
+            this._hasNext = false;
+        }
+        else {
+            Item radians = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
+            if (Item.isNumeric(radians)) {
+                Double result = Math.sin(Item.getNumericValue(radians, Double.class));
+                this._hasNext = true;
+                this.result = new DoubleItem(result,
+                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+            }
+            else {
+                throw new UnexpectedTypeException("Sin expression has non numeric args " +
+                        radians.serialize(), getMetadata());
+            }
+        }
+    }
+
+    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/SinFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/SinFunctionIterator.java
@@ -32,10 +32,7 @@ public class SinFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/SinFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/SinFunctionIterator.java
@@ -14,6 +14,9 @@ import sparksoniq.semantics.DynamicContext;
 import java.util.List;
 
 public class SinFunctionIterator extends LocalFunctionCallIterator {
+
+    private Item result;
+
     public SinFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, iteratorMetadata);
     }
@@ -23,8 +26,8 @@ public class SinFunctionIterator extends LocalFunctionCallIterator {
         if (this.hasNext()) {
             this._hasNext = false;
             return result;
-        } else
-            throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " sin function", getMetadata());
+        }
+        throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " sin function", getMetadata());
     }
 
     @Override
@@ -37,21 +40,17 @@ public class SinFunctionIterator extends LocalFunctionCallIterator {
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {
             this._hasNext = false;
-        }
-        else {
+        } else {
             Item radians = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
             if (Item.isNumeric(radians)) {
                 Double result = Math.sin(Item.getNumericValue(radians, Double.class));
                 this._hasNext = true;
                 this.result = new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));
-            }
-            else {
+            } else {
                 throw new UnexpectedTypeException("Sin expression has non numeric args " +
                         radians.serialize(), getMetadata());
             }
         }
     }
-
-    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/TanFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/TanFunctionIterator.java
@@ -9,6 +9,7 @@ import sparksoniq.jsoniq.runtime.iterator.EmptySequenceIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.LocalFunctionCallIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import java.util.List;
 
@@ -19,28 +20,38 @@ public class TanFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public Item next() {
-        if (this._hasNext) {
-            RuntimeIterator iterator = this._children.get(0);
-            //TODO refactor empty items
-            if (iterator.getClass() == EmptySequenceIterator.class) {
-                return null;
-            }
-            else {
-                Item radians = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
-                if (Item.isNumeric(radians)) {
-                    Double result = Math.tan(Item.getNumericValue(radians, Double.class));
-                    this._hasNext = false;
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
-                }
-                else {
-                    throw new UnexpectedTypeException("Tan expression has non numeric args " +
-                            radians.serialize(), getMetadata());
-                }
-            }
+        if (this.hasNext()) {
+            this._hasNext = false;
+            return result;
         } else
             throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " tan function", getMetadata());
     }
 
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
 
+        RuntimeIterator iterator = this._children.get(0);
+        if (iterator.getClass() == EmptySequenceIterator.class) {
+            this._hasNext = false;
+        }
+        else {
+            Item radians = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
+            if (Item.isNumeric(radians)) {
+                Double result = Math.tan(Item.getNumericValue(radians, Double.class));
+                this._hasNext = true;
+                this.result = new DoubleItem(result,
+                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+            }
+            else {
+                throw new UnexpectedTypeException("Tan expression has non numeric args " +
+                        radians.serialize(), getMetadata());
+            }
+        }
+    }
+
+    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/TanFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/TanFunctionIterator.java
@@ -14,6 +14,9 @@ import sparksoniq.semantics.DynamicContext;
 import java.util.List;
 
 public class TanFunctionIterator extends LocalFunctionCallIterator {
+
+    private Item result;
+
     public TanFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, iteratorMetadata);
     }
@@ -23,8 +26,8 @@ public class TanFunctionIterator extends LocalFunctionCallIterator {
         if (this.hasNext()) {
             this._hasNext = false;
             return result;
-        } else
-            throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " tan function", getMetadata());
+        }
+        throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " tan function", getMetadata());
     }
 
     @Override
@@ -37,21 +40,17 @@ public class TanFunctionIterator extends LocalFunctionCallIterator {
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {
             this._hasNext = false;
-        }
-        else {
+        } else {
             Item radians = this.getSingleItemOfTypeFromIterator(iterator, Item.class);
             if (Item.isNumeric(radians)) {
                 Double result = Math.tan(Item.getNumericValue(radians, Double.class));
                 this._hasNext = true;
                 this.result = new DoubleItem(result,
                         ItemMetadata.fromIteratorMetadata(getMetadata()));
-            }
-            else {
+            } else {
                 throw new UnexpectedTypeException("Tan expression has non numeric args " +
                         radians.serialize(), getMetadata());
             }
         }
     }
-
-    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/TanFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/TanFunctionIterator.java
@@ -32,10 +32,7 @@ public class TanFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         RuntimeIterator iterator = this._children.get(0);
         if (iterator.getClass() == EmptySequenceIterator.class) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectAccumulateFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectAccumulateFunctionIterator.java
@@ -14,6 +14,9 @@ import javax.naming.OperationNotSupportedException;
 import java.util.*;
 
 public class ObjectAccumulateFunctionIterator extends ObjectFunctionIterator {
+
+    private ObjectItem result;
+
     public ObjectAccumulateFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, ObjectFunctionOperators.ACCUMULATE, iteratorMetadata);
     }
@@ -32,7 +35,7 @@ public class ObjectAccumulateFunctionIterator extends ObjectFunctionIterator {
             // ignore non-object items
             if (item.isObject()) {
                 try {
-                    for (String key:item.getKeys()) {
+                    for (String key : item.getKeys()) {
                         Item value = item.getItemByKey(key);
                         if (!keyValuePairs.containsKey(key)) {
                             List<Item> valueList = new ArrayList<>();
@@ -63,6 +66,4 @@ public class ObjectAccumulateFunctionIterator extends ObjectFunctionIterator {
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " ACCUMULATE function",
                 getMetadata());
     }
-
-    ObjectItem result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectAccumulateFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectAccumulateFunctionIterator.java
@@ -23,10 +23,7 @@ public class ObjectAccumulateFunctionIterator extends ObjectFunctionIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         RuntimeIterator sequenceIterator = this._children.get(0);
         List<Item> items = getItemsFromIteratorWithCurrentContext(sequenceIterator);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectDescendantFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectDescendantFunctionIterator.java
@@ -28,10 +28,7 @@ public class ObjectDescendantFunctionIterator extends ObjectFunctionIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
         _currentIndex = 0;
         results = new ArrayList<>();
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectDescendantFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectDescendantFunctionIterator.java
@@ -6,6 +6,7 @@ import sparksoniq.jsoniq.item.ObjectItem;
 import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import javax.naming.OperationNotSupportedException;
 import java.util.ArrayList;
@@ -19,17 +20,30 @@ public class ObjectDescendantFunctionIterator extends ObjectFunctionIterator {
     @Override
     public Item next() {
         if (this._hasNext) {
-            if (results == null) {
-                _currentIndex = 0;
-                results = new ArrayList<>();
-                RuntimeIterator sequenceIterator = this._children.get(0);
-                List<Item> items = getItemsFromIteratorWithCurrentContext(sequenceIterator);
-                getDescendantObjects(items);
-            }
             return getResult();
         }
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " DESCENDANT-OBJECTS function",
                 getMetadata());
+    }
+
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
+        _currentIndex = 0;
+        results = new ArrayList<>();
+
+        RuntimeIterator sequenceIterator = this._children.get(0);
+        List<Item> items = getItemsFromIteratorWithCurrentContext(sequenceIterator);
+        getDescendantObjects(items);
+
+        if (results.size() == 0) {
+            this._hasNext = false;
+        } else {
+            this._hasNext = true;
+        }
     }
 
     public void getDescendantObjects(List<Item> items) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectDescendantFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectDescendantFunctionIterator.java
@@ -47,23 +47,21 @@ public class ObjectDescendantFunctionIterator extends ObjectFunctionIterator {
     }
 
     public void getDescendantObjects(List<Item> items) {
-        for (Item item:items) {
+        for (Item item : items) {
             if (item.isArray()) {
                 try {
                     getDescendantObjects(item.getItems());
                 } catch (OperationNotSupportedException e) {
                     e.printStackTrace();
                 }
-            }
-            else if (item.isObject()) {
+            } else if (item.isObject()) {
                 results.add(item);
                 try {
                     getDescendantObjects((List<Item>) item.getValues());
                 } catch (OperationNotSupportedException e) {
                     e.printStackTrace();
                 }
-            }
-            else {
+            } else {
                 // do nothing
             }
         }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectDescendantPairsFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectDescendantPairsFunctionIterator.java
@@ -48,18 +48,17 @@ public class ObjectDescendantPairsFunctionIterator extends ObjectFunctionIterato
     }
 
     public void getDescendantPairs(List<Item> items) {
-        for (Item item:items) {
+        for (Item item : items) {
             if (item.isArray()) {
                 try {
                     getDescendantPairs(item.getItems());
                 } catch (OperationNotSupportedException e) {
                     e.printStackTrace();
                 }
-            }
-            else if (item.isObject()) {
+            } else if (item.isObject()) {
                 try {
                     List<String> keys = item.getKeys();
-                    for (String key:keys) {
+                    for (String key : keys) {
                         Item value = item.getItemByKey(key);
 
                         List<String> keyList = Collections.singletonList(key);
@@ -72,8 +71,7 @@ public class ObjectDescendantPairsFunctionIterator extends ObjectFunctionIterato
                 } catch (OperationNotSupportedException e) {
                     e.printStackTrace();
                 }
-            }
-            else {
+            } else {
                 // do nothing
             }
         }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectDescendantPairsFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectDescendantPairsFunctionIterator.java
@@ -29,10 +29,7 @@ public class ObjectDescendantPairsFunctionIterator extends ObjectFunctionIterato
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
         _currentIndex = 0;
         results = new ArrayList<>();
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectDescendantPairsFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectDescendantPairsFunctionIterator.java
@@ -6,6 +6,7 @@ import sparksoniq.jsoniq.item.ObjectItem;
 import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import javax.naming.OperationNotSupportedException;
 import java.util.ArrayList;
@@ -19,18 +20,31 @@ public class ObjectDescendantPairsFunctionIterator extends ObjectFunctionIterato
 
     @Override
     public Item next() {
-        if (this._hasNext) {
-            if (results == null) {
-                _currentIndex = 0;
-                results = new ArrayList<>();
-                RuntimeIterator sequenceIterator = this._children.get(0);
-                List<Item> items = getItemsFromIteratorWithCurrentContext(sequenceIterator);
-                getDescendantPairs(items);
-            }
+        if (this.hasNext()) {
             return getResult();
         }
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " DESCENDANT-PAIRS function",
                 getMetadata());
+    }
+
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
+        _currentIndex = 0;
+        results = new ArrayList<>();
+
+        RuntimeIterator sequenceIterator = this._children.get(0);
+        List<Item> items = getItemsFromIteratorWithCurrentContext(sequenceIterator);
+        getDescendantPairs(items);
+
+        if (results.size() == 0) {
+            this._hasNext = false;
+        } else {
+            this._hasNext = true;
+        }
     }
 
     public void getDescendantPairs(List<Item> items) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectFunctionIterator.java
@@ -19,6 +19,7 @@
  */
 package sparksoniq.jsoniq.runtime.iterator.functions.object;
 
+import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.jsoniq.item.Item;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.LocalFunctionCallIterator;
@@ -45,10 +46,8 @@ public abstract class ObjectFunctionIterator extends LocalFunctionCallIterator {
     }
 
     public Item getResult() {
-        // if no results return empty sequence
         if (results == null || results.size() == 0) {
-            _hasNext = false;
-            return null;
+            throw new IteratorFlowException("getResult called on an empty list of results", getMetadata());
         }
         if (_currentIndex == results.size() - 1)
             _hasNext = false;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectFunctionUtilities.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectFunctionUtilities.java
@@ -8,8 +8,8 @@ import java.util.List;
 
 public class ObjectFunctionUtilities {
 
-    public static boolean listHasDuplicateString (List<Item> list, StringItem newItem) {
-        for (Item i:list) {
+    public static boolean listHasDuplicateString(List<Item> list, StringItem newItem) {
+        for (Item i : list) {
             try {
                 if (i.getStringValue().equals(newItem.getStringValue())) {
                     return true;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectIntersectFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectIntersectFunctionIterator.java
@@ -19,10 +19,7 @@ public class ObjectIntersectFunctionIterator extends ObjectFunctionIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         RuntimeIterator sequenceIterator = this._children.get(0);
         List<Item> items = getItemsFromIteratorWithCurrentContext(sequenceIterator);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectIntersectFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectIntersectFunctionIterator.java
@@ -34,25 +34,23 @@ public class ObjectIntersectFunctionIterator extends ObjectFunctionIterator {
                 try {
                     if (firstItem) {
                         // add all key-value pairs of the first item
-                        for (String key:item.getKeys()) {
+                        for (String key : item.getKeys()) {
                             Item value = item.getItemByKey(key);
                             ArrayList<Item> valueList = new ArrayList<>();
                             valueList.add(value);
                             keyValuePairs.put(key, valueList);
                         }
                         firstItem = false;
-                    }
-                    else {
+                    } else {
                         // iterate over existing keys in the map of results
-                        Iterator<String> keyIterator= keyValuePairs.keySet().iterator();
+                        Iterator<String> keyIterator = keyValuePairs.keySet().iterator();
                         while (keyIterator.hasNext()) {
                             String key = keyIterator.next();
                             // if the new item doesn't contain the same keys
-                            if (!item.getKeys().contains(key)){
+                            if (!item.getKeys().contains(key)) {
                                 // remove the key from the map
                                 keyIterator.remove();
-                            }
-                            else {
+                            } else {
                                 // add the matching key's value to the list
                                 Item value = item.getItemByKey(key);
                                 keyValuePairs.get(key).add(value);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectKeysFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectKeysFunctionIterator.java
@@ -22,10 +22,7 @@ public class ObjectKeysFunctionIterator extends ObjectFunctionIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
         _currentIndex = 0;
 
         results = new ArrayList<>();

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectKeysFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectKeysFunctionIterator.java
@@ -7,6 +7,8 @@ import sparksoniq.jsoniq.item.StringItem;
 import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
+
 import static sparksoniq.jsoniq.runtime.iterator.functions.object.ObjectFunctionUtilities.listHasDuplicateString;
 
 import javax.naming.OperationNotSupportedException;
@@ -19,37 +21,43 @@ public class ObjectKeysFunctionIterator extends ObjectFunctionIterator {
     }
 
     @Override
-    public Item next() {
-        if (this._hasNext) {
-            if (results == null) {
-                _currentIndex = 0;
-                results = new ArrayList<>();
-                RuntimeIterator sequenceIterator = this._children.get(0);
-                List<Item> items = getItemsFromIteratorWithCurrentContext(sequenceIterator);
-                for (Item item:items) {
-                    if (item.isObject()) {
-                        try {
-                            StringItem result = null;
-                            for (String key : item.getKeys()) {
-                                result = new StringItem(key, ItemMetadata.fromIteratorMetadata(getMetadata()));
-                                if (!listHasDuplicateString(results, result))
-                                {
-                                    results.add(result);
-                                }
-                            }
-                        } catch (OperationNotSupportedException e) {
-                            e.printStackTrace();
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
+        _currentIndex = 0;
+
+        results = new ArrayList<>();
+        RuntimeIterator sequenceIterator = this._children.get(0);
+        List<Item> items = getItemsFromIteratorWithCurrentContext(sequenceIterator);
+        for (Item item:items) {
+            if (item.isObject()) {
+                try {
+                    StringItem result = null;
+                    for (String key : item.getKeys()) {
+                        result = new StringItem(key, ItemMetadata.fromIteratorMetadata(getMetadata()));
+                        if (!listHasDuplicateString(results, result))
+                        {
+                            results.add(result);
                         }
                     }
+                } catch (OperationNotSupportedException e) {
+                    e.printStackTrace();
                 }
-
-                // single item algorithm doesn't work for sequences
-                /*
-                ObjectItem object = getSingleItemOfTypeFromIterator(objectIterator, ObjectItem.class);
-                for (String key : object.getKeys())
-                    results.add(new StringItem(key, ItemMetadata.fromIteratorMetadata(getMetadata())));
-                */
             }
+        }
+
+        if (results.size() == 0) {
+            this._hasNext = false;
+        } else {
+            this._hasNext = true;
+        }
+    }
+
+    @Override
+    public Item next() {
+        if (this._hasNext) {
             return getResult();
         }
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " KEYS function",

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectKeysFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectKeysFunctionIterator.java
@@ -31,14 +31,13 @@ public class ObjectKeysFunctionIterator extends ObjectFunctionIterator {
         results = new ArrayList<>();
         RuntimeIterator sequenceIterator = this._children.get(0);
         List<Item> items = getItemsFromIteratorWithCurrentContext(sequenceIterator);
-        for (Item item:items) {
+        for (Item item : items) {
             if (item.isObject()) {
                 try {
                     StringItem result = null;
                     for (String key : item.getKeys()) {
                         result = new StringItem(key, ItemMetadata.fromIteratorMetadata(getMetadata()));
-                        if (!listHasDuplicateString(results, result))
-                        {
+                        if (!listHasDuplicateString(results, result)) {
                             results.add(result);
                         }
                     }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectProjectFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectProjectFunctionIterator.java
@@ -49,11 +49,11 @@ public class ObjectProjectFunctionIterator extends ObjectFunctionIterator {
     }
 
     public void getProjection(List<Item> items, List<Item> keys) {
-        for (Item item:items) {
+        for (Item item : items) {
             if (item.isObject()) {
                 ArrayList<String> finalKeylist = new ArrayList<>();
                 ArrayList<Item> finalValueList = new ArrayList<>();
-                for (Item keyItem:keys) {
+                for (Item keyItem : keys) {
                     try {
                         String key = keyItem.getStringValue();
                         Item value = item.getItemByKey(key);
@@ -66,8 +66,7 @@ public class ObjectProjectFunctionIterator extends ObjectFunctionIterator {
                     }
                 }
                 results.add(new ObjectItem(finalKeylist, finalValueList, ItemMetadata.fromIteratorMetadata(getMetadata())));
-            }
-            else {
+            } else {
                 results.add(item);
             }
         }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectProjectFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectProjectFunctionIterator.java
@@ -7,6 +7,7 @@ import sparksoniq.jsoniq.item.ObjectItem;
 import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import javax.naming.OperationNotSupportedException;
 import java.util.ArrayList;
@@ -19,20 +20,32 @@ public class ObjectProjectFunctionIterator extends ObjectFunctionIterator {
 
     @Override
     public Item next() {
-        if (this._hasNext) {
-            if (results == null) {
-                _currentIndex = 0;
-                results = new ArrayList<>();
-                RuntimeIterator sequenceIterator = this._children.get(0);
-                RuntimeIterator keysIterator = this._children.get(1);
-                List<Item> items = getItemsFromIteratorWithCurrentContext(sequenceIterator);
-                List<Item> keys = getItemsFromIteratorWithCurrentContext(keysIterator);
-                getProjection(items, keys);
-            }
+        if (this.hasNext()) {
             return getResult();
         }
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " PROJECT function",
                 getMetadata());
+    }
+
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
+        _currentIndex = 0;
+        results = new ArrayList<>();
+        RuntimeIterator sequenceIterator = this._children.get(0);
+        RuntimeIterator keysIterator = this._children.get(1);
+        List<Item> items = getItemsFromIteratorWithCurrentContext(sequenceIterator);
+        List<Item> keys = getItemsFromIteratorWithCurrentContext(keysIterator);
+        getProjection(items, keys);
+
+        if (results.size() == 0) {
+            this._hasNext = false;
+        } else {
+            this._hasNext = true;
+        }
     }
 
     public void getProjection(List<Item> items, List<Item> keys) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectProjectFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectProjectFunctionIterator.java
@@ -29,12 +29,10 @@ public class ObjectProjectFunctionIterator extends ObjectFunctionIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
         _currentIndex = 0;
         results = new ArrayList<>();
+
         RuntimeIterator sequenceIterator = this._children.get(0);
         RuntimeIterator keysIterator = this._children.get(1);
         List<Item> items = getItemsFromIteratorWithCurrentContext(sequenceIterator);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectRemoveKeysFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectRemoveKeysFunctionIterator.java
@@ -49,13 +49,13 @@ public class ObjectRemoveKeysFunctionIterator extends ObjectFunctionIterator {
     }
 
     public void removeKeys(List<Item> items, List<Item> keysRemoveItems) {
-        for (Item item:items) {
+        for (Item item : items) {
             if (item.isObject()) {
                 ArrayList<String> finalKeylist = new ArrayList<>();
                 ArrayList<Item> finalValueList = new ArrayList<>();
                 ArrayList<String> keysToRemove = new ArrayList<>();
 
-                for (Item keyRemoveItem:keysRemoveItems) {
+                for (Item keyRemoveItem : keysRemoveItems) {
                     try {
                         String keyToRemove = keyRemoveItem.getStringValue();
                         keysToRemove.add(keyToRemove);
@@ -65,7 +65,7 @@ public class ObjectRemoveKeysFunctionIterator extends ObjectFunctionIterator {
                 }
 
                 try {
-                    for (String objectKey:item.getKeys()) {
+                    for (String objectKey : item.getKeys()) {
                         if (!keysToRemove.contains(objectKey)) {
                             finalKeylist.add(objectKey);
                             finalValueList.add(item.getItemByKey(objectKey));
@@ -76,8 +76,7 @@ public class ObjectRemoveKeysFunctionIterator extends ObjectFunctionIterator {
                 }
 
                 results.add(new ObjectItem(finalKeylist, finalValueList, ItemMetadata.fromIteratorMetadata(getMetadata())));
-            }
-            else {
+            } else {
                 results.add(item);
             }
         }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectRemoveKeysFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectRemoveKeysFunctionIterator.java
@@ -29,12 +29,10 @@ public class ObjectRemoveKeysFunctionIterator extends ObjectFunctionIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
         _currentIndex = 0;
         results = new ArrayList<>();
+
         RuntimeIterator sequenceIterator = this._children.get(0);
         RuntimeIterator keysIterator = this._children.get(1);
         List<Item> items = getItemsFromIteratorWithCurrentContext(sequenceIterator);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectValuesFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectValuesFunctionIterator.java
@@ -5,6 +5,7 @@ import sparksoniq.jsoniq.item.Item;
 import sparksoniq.jsoniq.item.ObjectItem;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,17 +18,29 @@ public class ObjectValuesFunctionIterator extends ObjectFunctionIterator {
     @Override
     public Item next() {
         if (this._hasNext) {
-            if (results == null) {
-                _currentIndex = 0;
-                results = new ArrayList<>();
-                RuntimeIterator objectIterator = this._children.get(0);
-                ObjectItem object = getSingleItemOfTypeFromIterator(objectIterator, ObjectItem.class);
-                for (Item item : object.getValues())
-                    results.add(item);
-            }
             return getResult();
         }
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " VALUES function",
                 getMetadata());
+    }
+
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
+        _currentIndex = 0;
+        results = new ArrayList<>();
+        RuntimeIterator objectIterator = this._children.get(0);
+        ObjectItem object = getSingleItemOfTypeFromIterator(objectIterator, ObjectItem.class);
+        for (Item item : object.getValues())
+            results.add(item);
+
+        if (results.size() == 0) {
+            this._hasNext = false;
+        } else {
+            this._hasNext = true;
+        }
     }
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectValuesFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectValuesFunctionIterator.java
@@ -26,12 +26,10 @@ public class ObjectValuesFunctionIterator extends ObjectFunctionIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
         _currentIndex = 0;
         results = new ArrayList<>();
+        
         RuntimeIterator objectIterator = this._children.get(0);
         ObjectItem object = getSingleItemOfTypeFromIterator(objectIterator, ObjectItem.class);
         for (Item item : object.getValues())

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/AvgFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/AvgFunctionIterator.java
@@ -6,6 +6,7 @@ import sparksoniq.jsoniq.item.Item;
 import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -17,25 +18,40 @@ public class AvgFunctionIterator extends AggregateFunctionIterator {
 
     @Override
     public Item next() {
-        if (this._hasNext) {
-            RuntimeIterator sequenceIterator = this._children.get(0);
-            List<Item> results = getItemsFromIteratorWithCurrentContext(sequenceIterator);
+        if (this.hasNext()) {
             this._hasNext = false;
-            results.forEach(r -> {
-                if (!Item.isNumeric(r))
-                    throw new IllegalArgumentException("Aggregate function argument is non numeric");
-            });
-            //TODO refactor empty items
-            if (results.size() == 0)
-                return null;
-            //TODO check numeric types conversions
-            BigDecimal sum = new BigDecimal(0);
-            for (Item r : results)
-                sum = sum.add(Item.getNumericValue(r, BigDecimal.class));
-            return new DecimalItem(sum.divide(new BigDecimal(results.size())),
-                    ItemMetadata.fromIteratorMetadata(getMetadata()));
+            return result;
         } else
             throw new IteratorFlowException(FLOW_EXCEPTION_MESSAGE + "AVG function",
                     getMetadata());
     }
+
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
+
+        RuntimeIterator sequenceIterator = this._children.get(0);
+        List<Item> results = getItemsFromIteratorWithCurrentContext(sequenceIterator);
+        results.forEach(r -> {
+            if (!Item.isNumeric(r))
+                throw new IllegalArgumentException("Aggregate function argument is non numeric");
+        });
+        if (results.size() == 0) {
+            this._hasNext = false;
+        }
+        else {
+            this._hasNext = true;
+        }
+        //TODO check numeric types conversions
+        BigDecimal sum = new BigDecimal(0);
+        for (Item r : results)
+            sum = sum.add(Item.getNumericValue(r, BigDecimal.class));
+        this.result = new DecimalItem(sum.divide(new BigDecimal(results.size())),
+                ItemMetadata.fromIteratorMetadata(getMetadata()));
+    }
+
+    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/AvgFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/AvgFunctionIterator.java
@@ -12,6 +12,9 @@ import java.math.BigDecimal;
 import java.util.List;
 
 public class AvgFunctionIterator extends AggregateFunctionIterator {
+
+    private Item result;
+
     public AvgFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, AggregateFunctionOperator.AVG, iteratorMetadata);
     }
@@ -21,9 +24,9 @@ public class AvgFunctionIterator extends AggregateFunctionIterator {
         if (this.hasNext()) {
             this._hasNext = false;
             return result;
-        } else
-            throw new IteratorFlowException(FLOW_EXCEPTION_MESSAGE + "AVG function",
-                    getMetadata());
+        } else {
+            throw new IteratorFlowException(FLOW_EXCEPTION_MESSAGE + "AVG function", getMetadata());
+        }
     }
 
     @Override
@@ -41,8 +44,7 @@ public class AvgFunctionIterator extends AggregateFunctionIterator {
         });
         if (results.size() == 0) {
             this._hasNext = false;
-        }
-        else {
+        } else {
             this._hasNext = true;
         }
         //TODO check numeric types conversions
@@ -52,6 +54,4 @@ public class AvgFunctionIterator extends AggregateFunctionIterator {
         this.result = new DecimalItem(sum.divide(new BigDecimal(results.size())),
                 ItemMetadata.fromIteratorMetadata(getMetadata()));
     }
-
-    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/AvgFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/AvgFunctionIterator.java
@@ -31,10 +31,7 @@ public class AvgFunctionIterator extends AggregateFunctionIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         RuntimeIterator sequenceIterator = this._children.get(0);
         List<Item> results = getItemsFromIteratorWithCurrentContext(sequenceIterator);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/CountFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/CountFunctionIterator.java
@@ -32,6 +32,9 @@ import sparksoniq.semantics.DynamicContext;
 import java.util.List;
 
 public class CountFunctionIterator extends AggregateFunctionIterator {
+
+    private Item result;
+
     public CountFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, AggregateFunctionIterator.AggregateFunctionOperator.COUNT, iteratorMetadata);
     }
@@ -41,9 +44,9 @@ public class CountFunctionIterator extends AggregateFunctionIterator {
         if (this.hasNext()) {
             this._hasNext = false;
             return result;
-        } else
-            throw new IteratorFlowException(FLOW_EXCEPTION_MESSAGE + " count function",
-                    getMetadata());
+        } else {
+            throw new IteratorFlowException(FLOW_EXCEPTION_MESSAGE + " count function", getMetadata());
+        }
     }
 
     @Override
@@ -59,7 +62,4 @@ public class CountFunctionIterator extends AggregateFunctionIterator {
         this.result = new IntegerItem(results.size(),
                 ItemMetadata.fromIteratorMetadata(getMetadata()));
     }
-
-    Item result;
-
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/CountFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/CountFunctionIterator.java
@@ -51,10 +51,7 @@ public class CountFunctionIterator extends AggregateFunctionIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         RuntimeIterator sequenceIterator = this._children.get(0);
         List<Item> results = getItemsFromIteratorWithCurrentContext(sequenceIterator);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/MaxFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/MaxFunctionIterator.java
@@ -10,6 +10,9 @@ import java.math.BigDecimal;
 import java.util.List;
 
 public class MaxFunctionIterator extends AggregateFunctionIterator {
+
+    private Item result;
+
     public MaxFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, AggregateFunctionOperator.MAX, iteratorMetadata);
     }
@@ -19,9 +22,9 @@ public class MaxFunctionIterator extends AggregateFunctionIterator {
         if (this.hasNext()) {
             this._hasNext = false;
             return result;
-        } else
-            throw new IteratorFlowException(FLOW_EXCEPTION_MESSAGE + "MAX function",
-                    getMetadata());
+        } else {
+            throw new IteratorFlowException(FLOW_EXCEPTION_MESSAGE + "MAX function", getMetadata());
+        }
     }
 
     @Override
@@ -54,6 +57,4 @@ public class MaxFunctionIterator extends AggregateFunctionIterator {
             this._hasNext = true;
         }
     }
-
-    Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/MaxFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/MaxFunctionIterator.java
@@ -29,10 +29,7 @@ public class MaxFunctionIterator extends AggregateFunctionIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         RuntimeIterator sequenceIterator = this._children.get(0);
         List<Item> results = getItemsFromIteratorWithCurrentContext(sequenceIterator);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/MinFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/MinFunctionIterator.java
@@ -29,10 +29,7 @@ public class MinFunctionIterator extends AggregateFunctionIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         RuntimeIterator sequenceIterator = this._children.get(0);
         List<Item> results = getItemsFromIteratorWithCurrentContext(sequenceIterator);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/MinFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/MinFunctionIterator.java
@@ -10,6 +10,9 @@ import java.math.BigDecimal;
 import java.util.List;
 
 public class MinFunctionIterator extends AggregateFunctionIterator {
+
+    private Item result;
+
     public MinFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, AggregateFunctionOperator.MIN, iteratorMetadata);
     }
@@ -19,9 +22,9 @@ public class MinFunctionIterator extends AggregateFunctionIterator {
         if (this.hasNext()) {
             this._hasNext = false;
             return result;
-        } else
-            throw new IteratorFlowException(FLOW_EXCEPTION_MESSAGE + "MIN function",
-                    getMetadata());
+        } else {
+            throw new IteratorFlowException(FLOW_EXCEPTION_MESSAGE + "MIN function", getMetadata());
+        }
     }
 
     @Override
@@ -53,7 +56,4 @@ public class MinFunctionIterator extends AggregateFunctionIterator {
             this._hasNext = true;
         }
     }
-
-    Item result;
-
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/MinFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/MinFunctionIterator.java
@@ -4,6 +4,7 @@ import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.jsoniq.item.Item;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -15,17 +16,30 @@ public class MinFunctionIterator extends AggregateFunctionIterator {
 
     @Override
     public Item next() {
-        if (this._hasNext) {
-            RuntimeIterator sequenceIterator = this._children.get(0);
-            List<Item> results = getItemsFromIteratorWithCurrentContext(sequenceIterator);
+        if (this.hasNext()) {
             this._hasNext = false;
-            results.forEach(r -> {
-                if (!Item.isNumeric(r))
-                    throw new IllegalArgumentException("Aggregate function argument is non numeric");
-            });
-            //TODO refactor empty items
-            if (results.size() == 0)
-                return null;
+            return result;
+        } else
+            throw new IteratorFlowException(FLOW_EXCEPTION_MESSAGE + "MIN function",
+                    getMetadata());
+    }
+
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
+
+        RuntimeIterator sequenceIterator = this._children.get(0);
+        List<Item> results = getItemsFromIteratorWithCurrentContext(sequenceIterator);
+        results.forEach(r -> {
+            if (!Item.isNumeric(r))
+                throw new IllegalArgumentException("Aggregate function argument is non numeric");
+        });
+        if (results.size() == 0) {
+            this._hasNext = false;
+        } else {
             Item itemResult = results.get(0);
             BigDecimal min = Item.getNumericValue(results.get(0), BigDecimal.class);
             for (Item r : results) {
@@ -35,9 +49,11 @@ public class MinFunctionIterator extends AggregateFunctionIterator {
                     itemResult = r;
                 }
             }
-            return itemResult;
-        } else
-            throw new IteratorFlowException(FLOW_EXCEPTION_MESSAGE + "MIN function",
-                    getMetadata());
+            this.result = itemResult;
+            this._hasNext = true;
+        }
     }
+
+    Item result;
+
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/SumFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/SumFunctionIterator.java
@@ -12,6 +12,9 @@ import java.math.BigDecimal;
 import java.util.List;
 
 public class SumFunctionIterator extends AggregateFunctionIterator {
+
+    private Item result;
+
     public SumFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, AggregateFunctionOperator.SUM, iteratorMetadata);
     }
@@ -21,9 +24,9 @@ public class SumFunctionIterator extends AggregateFunctionIterator {
         if (this.hasNext()) {
             this._hasNext = false;
             return result;
-        } else
-            throw new IteratorFlowException(FLOW_EXCEPTION_MESSAGE + "SUM function",
-                    getMetadata());
+        } else {
+            throw new IteratorFlowException(FLOW_EXCEPTION_MESSAGE + "SUM function", getMetadata());
+        }
     }
 
     @Override
@@ -49,7 +52,4 @@ public class SumFunctionIterator extends AggregateFunctionIterator {
         this.result = new DecimalItem(sumResult, ItemMetadata.fromIteratorMetadata(getMetadata()));
         this._hasNext = true;
     }
-
-    Item result;
-
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/SumFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/SumFunctionIterator.java
@@ -31,10 +31,7 @@ public class SumFunctionIterator extends AggregateFunctionIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         RuntimeIterator sequenceIterator = this._children.get(0);
         List<Item> results = getItemsFromIteratorWithCurrentContext(sequenceIterator);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/strings/ConcatFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/strings/ConcatFunctionIterator.java
@@ -30,10 +30,7 @@ public class ConcatFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         StringBuilder builder = new StringBuilder("");
         for (RuntimeIterator iterator : this._children) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/strings/ConcatFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/strings/ConcatFunctionIterator.java
@@ -7,6 +7,7 @@ import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.LocalFunctionCallIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import java.util.List;
 
@@ -17,15 +18,28 @@ public class ConcatFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public Item next() {
-        if (this._hasNext) {
-            StringBuilder builder = new StringBuilder("");
-            for (RuntimeIterator iterator : this._children) {
-                StringItem stringItem = this.getSingleItemOfTypeFromIterator(iterator, StringItem.class);
-                builder.append(stringItem.getStringValue());
-            }
+        if (this.hasNext()) {
             this._hasNext = false;
-            return new StringItem(builder.toString(), ItemMetadata.fromIteratorMetadata(getMetadata()));
+            return result;
         } else
             throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " substring function", getMetadata());
     }
+
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
+
+        StringBuilder builder = new StringBuilder("");
+        for (RuntimeIterator iterator : this._children) {
+            StringItem stringItem = this.getSingleItemOfTypeFromIterator(iterator, StringItem.class);
+            builder.append(stringItem.getStringValue());
+        }
+        this.result = new StringItem(builder.toString(), ItemMetadata.fromIteratorMetadata(getMetadata()));
+        this._hasNext = true;
+    }
+
+    private Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/strings/ConcatFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/strings/ConcatFunctionIterator.java
@@ -12,6 +12,9 @@ import sparksoniq.semantics.DynamicContext;
 import java.util.List;
 
 public class ConcatFunctionIterator extends LocalFunctionCallIterator {
+
+    private Item result;
+
     public ConcatFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, iteratorMetadata);
     }
@@ -40,6 +43,4 @@ public class ConcatFunctionIterator extends LocalFunctionCallIterator {
         this.result = new StringItem(builder.toString(), ItemMetadata.fromIteratorMetadata(getMetadata()));
         this._hasNext = true;
     }
-
-    private Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/strings/StringJoinFunction.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/strings/StringJoinFunction.java
@@ -31,10 +31,7 @@ public class StringJoinFunction extends LocalFunctionCallIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         StringItem joinString = new StringItem("", new ItemMetadata(getMetadata().getExpressionMetadata()));
         List<Item> strings = getItemsFromIteratorWithCurrentContext(this._children.get(0));

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/strings/StringJoinFunction.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/strings/StringJoinFunction.java
@@ -8,6 +8,7 @@ import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.LocalFunctionCallIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import java.util.List;
 
@@ -18,21 +19,35 @@ public class StringJoinFunction extends LocalFunctionCallIterator {
 
     @Override
     public Item next() {
-        if (this._hasNext) {
-            StringItem joinString = new StringItem("", new ItemMetadata(getMetadata().getExpressionMetadata()));
-            List<Item> strings = getItemsFromIteratorWithCurrentContext(this._children.get(0));
-            if (this._children.size() > 1)
-                joinString = getSingleItemOfTypeFromIterator(this._children.get(1), StringItem.class);
-            StringBuilder stringBuilder = new StringBuilder("");
-            for (Item item : strings) {
-                if (!(item instanceof StringItem))
-                    throw new UnexpectedTypeException("String item expected", this._children.get(0).getMetadata());
-                stringBuilder = !stringBuilder.toString().isEmpty() ? stringBuilder.append(joinString.getStringValue()) : stringBuilder;
-                stringBuilder = stringBuilder.append(((StringItem) item).getStringValue());
-            }
+        if (this.hasNext()) {
             this._hasNext = false;
-            return new StringItem(stringBuilder.toString(), ItemMetadata.fromIteratorMetadata(getMetadata()));
+            return result;
         } else
             throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " string-join function", getMetadata());
     }
+
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
+
+        StringItem joinString = new StringItem("", new ItemMetadata(getMetadata().getExpressionMetadata()));
+        List<Item> strings = getItemsFromIteratorWithCurrentContext(this._children.get(0));
+        if (this._children.size() > 1)
+            joinString = getSingleItemOfTypeFromIterator(this._children.get(1), StringItem.class);
+        StringBuilder stringBuilder = new StringBuilder("");
+        for (Item item : strings) {
+            if (!(item instanceof StringItem))
+                throw new UnexpectedTypeException("String item expected", this._children.get(0).getMetadata());
+            stringBuilder = !stringBuilder.toString().isEmpty() ? stringBuilder.append(joinString.getStringValue()) : stringBuilder;
+            stringBuilder = stringBuilder.append(((StringItem) item).getStringValue());
+        }
+        this.result = new StringItem(stringBuilder.toString(), ItemMetadata.fromIteratorMetadata(getMetadata()));
+        this._hasNext = true;
+    }
+
+    private Item result;
+
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/strings/StringJoinFunction.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/strings/StringJoinFunction.java
@@ -13,6 +13,9 @@ import sparksoniq.semantics.DynamicContext;
 import java.util.List;
 
 public class StringJoinFunction extends LocalFunctionCallIterator {
+
+    private Item result;
+
     public StringJoinFunction(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, iteratorMetadata);
     }
@@ -47,7 +50,4 @@ public class StringJoinFunction extends LocalFunctionCallIterator {
         this.result = new StringItem(stringBuilder.toString(), ItemMetadata.fromIteratorMetadata(getMetadata()));
         this._hasNext = true;
     }
-
-    private Item result;
-
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/strings/SubstringFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/strings/SubstringFunctionIterator.java
@@ -13,6 +13,9 @@ import sparksoniq.semantics.DynamicContext;
 import java.util.List;
 
 public class SubstringFunctionIterator extends LocalFunctionCallIterator {
+
+    private Item result;
+    
     public SubstringFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, iteratorMetadata);
     }
@@ -58,6 +61,4 @@ public class SubstringFunctionIterator extends LocalFunctionCallIterator {
         //char indexing starts from 1 in JSONiq
         return indexItem.getIntegerValue() - 1 > 0 ? indexItem.getIntegerValue() - 1 : 0;
     }
-
-    private Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/strings/SubstringFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/strings/SubstringFunctionIterator.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class SubstringFunctionIterator extends LocalFunctionCallIterator {
 
     private Item result;
-    
+
     public SubstringFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, iteratorMetadata);
     }
@@ -31,10 +31,7 @@ public class SubstringFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         String result;
         StringItem stringItem = this.getSingleItemOfTypeFromIterator(this._children.get(0), StringItem.class);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/strings/SubstringFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/strings/SubstringFunctionIterator.java
@@ -8,6 +8,7 @@ import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.LocalFunctionCallIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import java.util.List;
 
@@ -18,23 +19,34 @@ public class SubstringFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public Item next() {
-        if (this._hasNext) {
-            String result;
-            StringItem stringItem = this.getSingleItemOfTypeFromIterator(this._children.get(0), StringItem.class);
-            IntegerItem indexItem = this.getSingleItemOfTypeFromIterator(this._children.get(1), IntegerItem.class);
-            int index = sanitizeIndexItem(indexItem);
-            if (this._children.size() > 2) {
-                IntegerItem endIndexItem = this.getSingleItemOfTypeFromIterator(this._children.get(2), IntegerItem.class);
-                int endIndex = sanitizeEndIndex(stringItem, endIndexItem, index);
-                result = stringItem.getStringValue().substring(index, endIndex);
-            } else {
-                result = stringItem.getStringValue().substring(index);
-            }
-
+        if (this.hasNext()) {
             this._hasNext = false;
-            return new StringItem(result, ItemMetadata.fromIteratorMetadata(getMetadata()));
+            return result;
         } else
             throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " substring function", getMetadata());
+    }
+
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
+
+        String result;
+        StringItem stringItem = this.getSingleItemOfTypeFromIterator(this._children.get(0), StringItem.class);
+        IntegerItem indexItem = this.getSingleItemOfTypeFromIterator(this._children.get(1), IntegerItem.class);
+        int index = sanitizeIndexItem(indexItem);
+        if (this._children.size() > 2) {
+            IntegerItem endIndexItem = this.getSingleItemOfTypeFromIterator(this._children.get(2), IntegerItem.class);
+            int endIndex = sanitizeEndIndex(stringItem, endIndexItem, index);
+            result = stringItem.getStringValue().substring(index, endIndex);
+        } else {
+            result = stringItem.getStringValue().substring(index);
+        }
+
+        this.result = new StringItem(result, ItemMetadata.fromIteratorMetadata(getMetadata()));
+        this._hasNext = true;
     }
 
     private int sanitizeEndIndex(StringItem stringItem, IntegerItem endIndexItem, int startIndex) {
@@ -46,4 +58,6 @@ public class SubstringFunctionIterator extends LocalFunctionCallIterator {
         //char indexing starts from 1 in JSONiq
         return indexItem.getIntegerValue() - 1 > 0 ? indexItem.getIntegerValue() - 1 : 0;
     }
+
+    private Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/AdditiveOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/AdditiveOperationIterator.java
@@ -37,7 +37,7 @@ import java.math.BigDecimal;
 public class AdditiveOperationIterator extends BinaryOperationBaseIterator {
 
     private AtomicItem result;
-    
+
     public AdditiveOperationIterator(RuntimeIterator left, RuntimeIterator right,
                                      OperationalExpressionBase.Operator operator, IteratorMetadata iteratorMetadata) {
         super(left, right, operator, iteratorMetadata);
@@ -45,10 +45,7 @@ public class AdditiveOperationIterator extends BinaryOperationBaseIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         if (_leftIterator instanceof EmptySequenceIterator || _rightIterator instanceof EmptySequenceIterator) {
             this._hasNext = false;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/AdditiveOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/AdditiveOperationIterator.java
@@ -17,7 +17,7 @@
  * Author: Stefan Irimescu
  *
  */
- package sparksoniq.jsoniq.runtime.iterator.operational;
+package sparksoniq.jsoniq.runtime.iterator.operational;
 
 import sparksoniq.exceptions.UnexpectedTypeException;
 import sparksoniq.jsoniq.item.*;
@@ -36,9 +36,11 @@ import java.math.BigDecimal;
 
 public class AdditiveOperationIterator extends BinaryOperationBaseIterator {
 
+    private AtomicItem result;
+    
     public AdditiveOperationIterator(RuntimeIterator left, RuntimeIterator right,
                                      OperationalExpressionBase.Operator operator, IteratorMetadata iteratorMetadata) {
-        super(left,right,operator, iteratorMetadata);
+        super(left, right, operator, iteratorMetadata);
     }
 
     @Override
@@ -48,41 +50,40 @@ public class AdditiveOperationIterator extends BinaryOperationBaseIterator {
         this._isOpen = true;
         this._currentDynamicContext = context;
 
-        if(_leftIterator instanceof EmptySequenceIterator || _rightIterator instanceof EmptySequenceIterator){
+        if (_leftIterator instanceof EmptySequenceIterator || _rightIterator instanceof EmptySequenceIterator) {
             this._hasNext = false;
-        }
-        else {
+        } else {
             _leftIterator.open(_currentDynamicContext);
             _rightIterator.open(_currentDynamicContext);
             Item left = _leftIterator.next();
             Item right = _rightIterator.next();
-            if(!Item.isNumeric(left) || !Item.isNumeric(right))
+            if (!Item.isNumeric(left) || !Item.isNumeric(right))
                 throw new UnexpectedTypeException("Additive expression has non numeric args " +
                         left.serialize() + ", " + right.serialize(), getMetadata());
             _leftIterator.close();
             _rightIterator.close();
 
             Type returnType = Item.getNumericResultType(left, right);
-            if(returnType.equals(IntegerItem.class)){
+            if (returnType.equals(IntegerItem.class)) {
                 int l = Item.<Integer>getNumericValue(left, Integer.class);
                 int r = Item.<Integer>getNumericValue(right, Integer.class);
-                this.result = this._operator == OperationalExpressionBase.Operator.PLUS?
+                this.result = this._operator == OperationalExpressionBase.Operator.PLUS ?
                         new IntegerItem(l + r,
                                 ItemMetadata.fromIteratorMetadata(getMetadata())) :
                         new IntegerItem(l - r,
                                 ItemMetadata.fromIteratorMetadata(getMetadata()));
-            } else if(returnType.equals(DoubleItem.class)){
+            } else if (returnType.equals(DoubleItem.class)) {
                 double l = Item.<Double>getNumericValue(left, Double.class);
                 double r = Item.<Double>getNumericValue(right, Double.class);
-                this.result = this._operator == OperationalExpressionBase.Operator.PLUS?
+                this.result = this._operator == OperationalExpressionBase.Operator.PLUS ?
                         new DoubleItem(l + r,
                                 ItemMetadata.fromIteratorMetadata(getMetadata())) :
                         new DoubleItem(l - r,
                                 ItemMetadata.fromIteratorMetadata(getMetadata()));
-            } else if(returnType.equals(DecimalItem.class)){
+            } else if (returnType.equals(DecimalItem.class)) {
                 BigDecimal l = Item.<BigDecimal>getNumericValue(left, BigDecimal.class);
                 BigDecimal r = Item.<BigDecimal>getNumericValue(right, BigDecimal.class);
-                this.result = this._operator == OperationalExpressionBase.Operator.PLUS?
+                this.result = this._operator == OperationalExpressionBase.Operator.PLUS ?
                         new DecimalItem(l.add(r),
                                 ItemMetadata.fromIteratorMetadata(getMetadata())) :
                         new DecimalItem(l.subtract(r),
@@ -96,14 +97,11 @@ public class AdditiveOperationIterator extends BinaryOperationBaseIterator {
 
     @Override
     public AtomicItem next() {
-        if(this.hasNext()){
+        if (this.hasNext()) {
             this._hasNext = false;
             return result;
-        }
-        else {
+        } else {
             throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE, getMetadata());
         }
     }
-
-    AtomicItem result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/AndOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/AndOperationIterator.java
@@ -40,11 +40,7 @@ public class AndOperationIterator extends BinaryOperationBaseIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._hasNext = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         _leftIterator.open(_currentDynamicContext);
         _rightIterator.open(_currentDynamicContext);
@@ -54,11 +50,12 @@ public class AndOperationIterator extends BinaryOperationBaseIterator {
         _rightIterator.close();
         this.result = new BooleanItem(Item.getEffectiveBooleanValue(left) && Item.getEffectiveBooleanValue(right)
                 , ItemMetadata.fromIteratorMetadata(getMetadata()));
+        this._hasNext = true;
     }
 
     @Override
     public AtomicItem next() {
-        if (this._hasNext) {
+        if (this.hasNext()) {
             this._hasNext = false;
             return result;
         }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/AndOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/AndOperationIterator.java
@@ -32,6 +32,8 @@ import sparksoniq.semantics.DynamicContext;
 
 public class AndOperationIterator extends BinaryOperationBaseIterator {
 
+    private BooleanItem result;
+
     public AndOperationIterator(RuntimeIterator left, RuntimeIterator right, IteratorMetadata iteratorMetadata) {
         super(left, right, OperationalExpressionBase.Operator.AND, iteratorMetadata);
     }
@@ -62,6 +64,4 @@ public class AndOperationIterator extends BinaryOperationBaseIterator {
         }
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE, getMetadata());
     }
-
-    BooleanItem result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/ComparisonOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/ComparisonOperationIterator.java
@@ -42,12 +42,12 @@ import java.util.Arrays;
 
 
 public class ComparisonOperationIterator extends BinaryOperationBaseIterator {
-    public static final Operator[] valueComparisonOperators = new Operator[] {
+    public static final Operator[] valueComparisonOperators = new Operator[]{
             Operator.VC_GE, Operator.VC_GT, Operator.VC_EQ, Operator.VC_NE, Operator.VC_LE, Operator.VC_LT};
-    public static final Operator[] generalComparisonOperators = new Operator[] {
+    public static final Operator[] generalComparisonOperators = new Operator[]{
             Operator.GC_GE, Operator.GC_GT, Operator.GC_EQ, Operator.GC_NE, Operator.GC_LE, Operator.GC_LT};
 
-    protected AtomicItem result;
+    private AtomicItem result;
 
 
     public ComparisonOperationIterator(RuntimeIterator left, RuntimeIterator right,
@@ -57,7 +57,7 @@ public class ComparisonOperationIterator extends BinaryOperationBaseIterator {
 
     @Override
     public AtomicItem next() {
-        if(this.hasNext()){
+        if (this.hasNext()) {
             this._hasNext = false;
             return result;
         }
@@ -74,7 +74,7 @@ public class ComparisonOperationIterator extends BinaryOperationBaseIterator {
         _leftIterator.open(_currentDynamicContext);
         _rightIterator.open(_currentDynamicContext);
 
-        if (Arrays.asList(valueComparisonOperators).contains(this._operator)){
+        if (Arrays.asList(valueComparisonOperators).contains(this._operator)) {
 
             // if EMPTY SEQUENCE - eg. () or ((),())
             // this check is added here to provide lazy evaluation: eg. () eq (2,3) = () instead of exception
@@ -85,18 +85,15 @@ public class ComparisonOperationIterator extends BinaryOperationBaseIterator {
                 Item right = _rightIterator.next();
 
                 // value comparison doesn't support more than 1 items
-                if (_leftIterator.hasNext() || _rightIterator.hasNext())
-                {
+                if (_leftIterator.hasNext() || _rightIterator.hasNext()) {
                     throw new UnexpectedTypeException("Invalid args. Value comparison can't be performed on sequences with more than 1 items", getMetadata());
-                }
-                else {
+                } else {
                     result = comparePair(left, right);
                 }
             }
             _leftIterator.close();
             _rightIterator.close();
-        }
-        else if (Arrays.asList(generalComparisonOperators).contains(this._operator)) {
+        } else if (Arrays.asList(generalComparisonOperators).contains(this._operator)) {
             ArrayList<Item> left = new ArrayList<>();
             ArrayList<Item> right = new ArrayList<>();
             while (_leftIterator.hasNext())
@@ -110,7 +107,7 @@ public class ComparisonOperationIterator extends BinaryOperationBaseIterator {
             result = compareAllPairs(left, right);
         }
 
-        if(result == null) {
+        if (result == null) {
             this._hasNext = false;
         } else {
             this._hasNext = true;
@@ -119,13 +116,14 @@ public class ComparisonOperationIterator extends BinaryOperationBaseIterator {
 
     /**
      * Function to compare two lists of items one by one with each other.
+     *
      * @param left  item list of left iterator
      * @param right item list of right iterator
      * @return true if a single match is found, false if no matches. Given an empty sequence, false is returned.
      */
-    public BooleanItem compareAllPairs (ArrayList<Item> left, ArrayList<Item> right) {
-        for (Item l:left) {
-            for (Item r:right) {
+    public BooleanItem compareAllPairs(ArrayList<Item> left, ArrayList<Item> right) {
+        for (Item l : left) {
+            for (Item r : right) {
                 BooleanItem result = comparePair(l, r);
                 if (result.getBooleanValue() == true)
                     return result;
@@ -138,37 +136,32 @@ public class ComparisonOperationIterator extends BinaryOperationBaseIterator {
 
         if (left instanceof ArrayItem || right instanceof ArrayItem) {
             throw new NonAtomicKeyException("Invalid args. Comparison can't be performed on array type", getMetadata().getExpressionMetadata());
-        }
-        else if (left instanceof ObjectItem || right instanceof ObjectItem) {
+        } else if (left instanceof ObjectItem || right instanceof ObjectItem) {
             throw new NonAtomicKeyException("Invalid args. Comparison can't be performed on object type", getMetadata().getExpressionMetadata());
         }
         if (left instanceof NullItem || right instanceof NullItem) {
             return compareItems(left, right);
-        }
-        else if (Item.isNumeric(left)) {
+        } else if (Item.isNumeric(left)) {
             if (!Item.isNumeric(right))
                 throw new UnexpectedTypeException("Invalid args for numerics comparison " + left.serialize() +
                         ", " + right.serialize(), getMetadata());
             return compareItems(left, right);
-        }
-        else if (left instanceof StringItem) {
+        } else if (left instanceof StringItem) {
             if (!(right instanceof StringItem))
                 throw new UnexpectedTypeException("Invalid args for string comparison " + left.serialize() +
                         ", " + right.serialize(), getMetadata());
             return compareItems(left, right);
-        }
-        else if (left instanceof BooleanItem) {
+        } else if (left instanceof BooleanItem) {
             if (!(right instanceof BooleanItem))
                 throw new UnexpectedTypeException("Invalid args for boolean comparison " + left.serialize() +
                         ", " + right.serialize(), getMetadata());
             return compareItems(left, right);
-        }
-        else {
+        } else {
             throw new IteratorFlowException("Invalid comparison expression", getMetadata());
         }
     }
 
-    public BooleanItem compareItems (Item left, Item right) {
+    public BooleanItem compareItems(Item left, Item right) {
         int comparison = Item.compareItems(left, right);
         switch (this._operator) {
             case VC_EQ:
@@ -192,5 +185,4 @@ public class ComparisonOperationIterator extends BinaryOperationBaseIterator {
         }
         throw new IteratorFlowException("Unrecognized operator found", getMetadata());
     }
-
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/ComparisonOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/ComparisonOperationIterator.java
@@ -66,10 +66,7 @@ public class ComparisonOperationIterator extends BinaryOperationBaseIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         _leftIterator.open(_currentDynamicContext);
         _rightIterator.open(_currentDynamicContext);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/InstanceOfIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/InstanceOfIterator.java
@@ -45,10 +45,7 @@ public class InstanceOfIterator extends UnaryOperationIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         List<Item> items = new ArrayList<>();
         _child.open(_currentDynamicContext);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/InstanceOfIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/InstanceOfIterator.java
@@ -36,7 +36,7 @@ import java.util.List;
 public class InstanceOfIterator extends UnaryOperationIterator {
 
     private final SequenceType _sequenceType;
-    protected AtomicItem result;
+    private AtomicItem result;
 
     public InstanceOfIterator(RuntimeIterator child, SequenceType sequenceType, IteratorMetadata iteratorMetadata) {
         super(child, OperationalExpressionBase.Operator.INSTANCE_OF, iteratorMetadata);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/MultiplicativeOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/MultiplicativeOperationIterator.java
@@ -44,10 +44,7 @@ public class MultiplicativeOperationIterator extends BinaryOperationBaseIterator
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         if (_leftIterator instanceof EmptySequenceIterator || _rightIterator instanceof EmptySequenceIterator) {
             this._hasNext = false;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/MultiplicativeOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/MultiplicativeOperationIterator.java
@@ -35,6 +35,8 @@ import java.math.BigDecimal;
 
 public class MultiplicativeOperationIterator extends BinaryOperationBaseIterator {
 
+    private AtomicItem result;
+
     public MultiplicativeOperationIterator(RuntimeIterator left, RuntimeIterator right,
                                            OperationalExpressionBase.Operator operator, IteratorMetadata iteratorMetadata) {
         super(left, right, operator, iteratorMetadata);
@@ -131,6 +133,4 @@ public class MultiplicativeOperationIterator extends BinaryOperationBaseIterator
         }
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE, getMetadata());
     }
-
-    AtomicItem result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/NotOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/NotOperationIterator.java
@@ -17,7 +17,7 @@
  * Author: Stefan Irimescu
  *
  */
- package sparksoniq.jsoniq.runtime.iterator.operational;
+package sparksoniq.jsoniq.runtime.iterator.operational;
 
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.jsoniq.item.AtomicItem;
@@ -32,7 +32,7 @@ import sparksoniq.semantics.DynamicContext;
 
 public class NotOperationIterator extends UnaryOperationBaseIterator {
 
-    BooleanItem result;
+    private BooleanItem result;
 
     public NotOperationIterator(RuntimeIterator child, IteratorMetadata iteratorMetadata) {
         super(child, OperationalExpressionBase.Operator.NOT, iteratorMetadata);
@@ -53,7 +53,7 @@ public class NotOperationIterator extends UnaryOperationBaseIterator {
 
     @Override
     public AtomicItem next() {
-        if(this.hasNext()){
+        if (this.hasNext()) {
             this._hasNext = false;
             return this.result;
         }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/NotOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/NotOperationIterator.java
@@ -40,10 +40,8 @@ public class NotOperationIterator extends UnaryOperationBaseIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
+
         _child.open(_currentDynamicContext);
         Item child = _child.next();
         _child.close();

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/OrOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/OrOperationIterator.java
@@ -38,10 +38,8 @@ public class OrOperationIterator extends BinaryOperationBaseIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
+
         _leftIterator.open(_currentDynamicContext);
         _rightIterator.open(_currentDynamicContext);
         Item left = _leftIterator.next();

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/OrOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/OrOperationIterator.java
@@ -17,7 +17,7 @@
  * Author: Stefan Irimescu
  *
  */
- package sparksoniq.jsoniq.runtime.iterator.operational;
+package sparksoniq.jsoniq.runtime.iterator.operational;
 
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.jsoniq.item.*;
@@ -30,10 +30,10 @@ import sparksoniq.semantics.DynamicContext;
 
 public class OrOperationIterator extends BinaryOperationBaseIterator {
 
-    BooleanItem result;
+    private BooleanItem result;
 
     public OrOperationIterator(RuntimeIterator left, RuntimeIterator right, IteratorMetadata iteratorMetadata) {
-        super(left,right, OperationalExpressionBase.Operator.OR, iteratorMetadata);
+        super(left, right, OperationalExpressionBase.Operator.OR, iteratorMetadata);
     }
 
     @Override
@@ -55,7 +55,7 @@ public class OrOperationIterator extends BinaryOperationBaseIterator {
 
     @Override
     public AtomicItem next() {
-        if(this.hasNext()) {
+        if (this.hasNext()) {
             this._hasNext = false;
             return this.result;
         }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/RangeOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/RangeOperationIterator.java
@@ -33,13 +33,17 @@ import sparksoniq.semantics.DynamicContext;
 
 public class RangeOperationIterator extends BinaryOperationBaseIterator {
 
+    private int _left;
+    private int _right;
+    private int _index;
+
     public RangeOperationIterator(RuntimeIterator left, RuntimeIterator right, IteratorMetadata iteratorMetadata) {
         super(left, right, OperationalExpressionBase.Operator.TO, iteratorMetadata);
     }
 
     @Override
     public AtomicItem next() {
-        if(_hasNext == true){
+        if (_hasNext == true) {
             if (_index == _right)
                 this._hasNext = false;
             return new IntegerItem(_index++, ItemMetadata.fromIteratorMetadata(getMetadata()));
@@ -74,8 +78,4 @@ public class RangeOperationIterator extends BinaryOperationBaseIterator {
             this._hasNext = true;
         }
     }
-
-    private int _left;
-    private int _right;
-    private int _index;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/RangeOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/RangeOperationIterator.java
@@ -53,10 +53,7 @@ public class RangeOperationIterator extends BinaryOperationBaseIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         _index = 0;
         _leftIterator.open(_currentDynamicContext);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/StringConcatIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/StringConcatIterator.java
@@ -41,10 +41,7 @@ public class StringConcatIterator extends BinaryOperationBaseIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         _leftIterator.open(_currentDynamicContext);
         _rightIterator.open(_currentDynamicContext);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/StringConcatIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/StringConcatIterator.java
@@ -29,29 +29,45 @@ import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.operational.base.BinaryOperationBaseIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 public class StringConcatIterator extends BinaryOperationBaseIterator {
+
+    StringItem result;
+
     public StringConcatIterator(RuntimeIterator left, RuntimeIterator right, IteratorMetadata iteratorMetadata) {
         super(left, right, OperationalExpressionBase.Operator.CONCAT, iteratorMetadata);
     }
 
     @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
+
+        _leftIterator.open(_currentDynamicContext);
+        _rightIterator.open(_currentDynamicContext);
+        Item left = _leftIterator.next();
+        Item right = _rightIterator.next();
+        if (!(left instanceof StringItem) || !(right instanceof StringItem))
+            throw new UnexpectedTypeException("String concat expression has non strings args " +
+                    left.serialize() + ", " + right.serialize(), getMetadata());
+        StringItem leftString = (StringItem) left;
+        StringItem rightString = (StringItem) right;
+        _leftIterator.close();
+        _rightIterator.close();
+
+        this.result = new StringItem(leftString.getStringValue().concat(rightString.getStringValue()),
+                ItemMetadata.fromIteratorMetadata(getMetadata()));
+        this._hasNext = true;
+    }
+
+    @Override
     public AtomicItem next() {
         if (this.hasNext()) {
-            _leftIterator.open(_currentDynamicContext);
-            _rightIterator.open(_currentDynamicContext);
-            Item left = _leftIterator.next();
-            Item right = _rightIterator.next();
-            if (!(left instanceof StringItem) || !(right instanceof StringItem))
-                throw new UnexpectedTypeException("String concat expression has non strings args " +
-                        left.serialize() + ", " + right.serialize(), getMetadata());
-            StringItem leftString = (StringItem) left;
-            StringItem rightString = (StringItem) right;
-            _leftIterator.close();
-            _rightIterator.close();
             this._hasNext = false;
-            return new StringItem(leftString.getStringValue().concat(rightString.getStringValue()),
-                    ItemMetadata.fromIteratorMetadata(getMetadata()));
+            return this.result;
         }
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE, getMetadata());
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/StringConcatIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/StringConcatIterator.java
@@ -33,7 +33,7 @@ import sparksoniq.semantics.DynamicContext;
 
 public class StringConcatIterator extends BinaryOperationBaseIterator {
 
-    StringItem result;
+    private StringItem result;
 
     public StringConcatIterator(RuntimeIterator left, RuntimeIterator right, IteratorMetadata iteratorMetadata) {
         super(left, right, OperationalExpressionBase.Operator.CONCAT, iteratorMetadata);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/UnaryOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/UnaryOperationIterator.java
@@ -17,7 +17,7 @@
  * Author: Stefan Irimescu
  *
  */
- package sparksoniq.jsoniq.runtime.iterator.operational;
+package sparksoniq.jsoniq.runtime.iterator.operational;
 
 import sparksoniq.exceptions.UnexpectedTypeException;
 import sparksoniq.jsoniq.item.*;
@@ -34,7 +34,7 @@ import java.math.BigDecimal;
 
 public class UnaryOperationIterator extends UnaryOperationBaseIterator {
 
-    Item result;
+    private Item result;
 
     public UnaryOperationIterator(RuntimeIterator child, OperationalExpressionBase.Operator operator,
                                   IteratorMetadata iteratorMetadata) {
@@ -48,27 +48,25 @@ public class UnaryOperationIterator extends UnaryOperationBaseIterator {
         this._isOpen = true;
         this._currentDynamicContext = context;
 
-        if(_child instanceof EmptySequenceIterator){
+        if (_child instanceof EmptySequenceIterator) {
             this._hasNext = false;
         }
 
         _child.open(_currentDynamicContext);
         Item child = _child.next();
         _child.close();
-        if(this._operator== OperationalExpressionBase.Operator.MINUS)
-        {
-            if(Item.isNumeric(child)){
-                if(child instanceof IntegerItem)
-                    this.result = new IntegerItem(-1 * ((IntegerItem)child).getIntegerValue(),
+        if (this._operator == OperationalExpressionBase.Operator.MINUS) {
+            if (Item.isNumeric(child)) {
+                if (child instanceof IntegerItem)
+                    this.result = new IntegerItem(-1 * ((IntegerItem) child).getIntegerValue(),
                             ItemMetadata.fromIteratorMetadata(getMetadata()));
-                if(child instanceof DoubleItem)
-                    this.result =  new DoubleItem(-1 * ((DoubleItem)child).getDoubleValue(),
+                if (child instanceof DoubleItem)
+                    this.result = new DoubleItem(-1 * ((DoubleItem) child).getDoubleValue(),
                             ItemMetadata.fromIteratorMetadata(getMetadata()));
-                if(child instanceof DecimalItem)
-                    this.result =  new DecimalItem(((DecimalItem)child).getDecimalValue().multiply(new BigDecimal(-1)),
+                if (child instanceof DecimalItem)
+                    this.result = new DecimalItem(((DecimalItem) child).getDecimalValue().multiply(new BigDecimal(-1)),
                             ItemMetadata.fromIteratorMetadata(getMetadata()));
-            }
-            else {
+            } else {
                 throw new UnexpectedTypeException("Unary expression has non numeric args " +
                         child.serialize(), getMetadata());
             }
@@ -81,7 +79,7 @@ public class UnaryOperationIterator extends UnaryOperationBaseIterator {
 
     @Override
     public Item next() {
-        if(this.hasNext()){
+        if (this.hasNext()) {
             this._hasNext = false;
             return result;
         }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/UnaryOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/UnaryOperationIterator.java
@@ -43,10 +43,7 @@ public class UnaryOperationIterator extends UnaryOperationBaseIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         if (_child instanceof EmptySequenceIterator) {
             this._hasNext = false;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ArrayLookupIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ArrayLookupIterator.java
@@ -27,6 +27,7 @@ import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.jsoniq.runtime.iterator.LocalRuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 public class ArrayLookupIterator extends LocalRuntimeIterator {
     public ArrayLookupIterator(RuntimeIterator array, RuntimeIterator iterator, IteratorMetadata iteratorMetadata) {
@@ -37,26 +38,38 @@ public class ArrayLookupIterator extends LocalRuntimeIterator {
 
     @Override
     public Item next() {
-        if(this._hasNext) {
-            this._children.get(0).open(_currentDynamicContext);
-            this._children.get(1).open(_currentDynamicContext);
-            this._array = (ArrayItem) this._children.get(0).next();
-            Item lookup = this._children.get(1).next();
-            if(this._children.get(1).hasNext() || lookup.isObject() || lookup.isArray())
-                throw new InvalidSelectorException("Type error; There is not exactly one supplied parameter for an array selector: "
-                        + lookup.serialize(), getMetadata());
-            if(!Item.isNumeric(lookup))
-                throw new UnexpectedTypeException("Non numeric array lookup for " + lookup.serialize(), getMetadata());
-            this._lookup = Item.getNumericValue(lookup, Integer.class);
-            this._children.get(0).close();
-            this._children.get(1).close();
+        if (this.hasNext()) {
             this._hasNext = false;
-            //-1 for Jsoniq convetion, arrays start from 1
-            return _array.getItemAt(_lookup - 1);
+            return result;
         }
         throw new IteratorFlowException("Invalid next call in Array Lookup", getMetadata());
     }
 
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
+
+        this._children.get(0).open(_currentDynamicContext);
+        this._children.get(1).open(_currentDynamicContext);
+        this._array = (ArrayItem) this._children.get(0).next();
+        Item lookup = this._children.get(1).next();
+        if(this._children.get(1).hasNext() || lookup.isObject() || lookup.isArray())
+            throw new InvalidSelectorException("Type error; There is not exactly one supplied parameter for an array selector: "
+                    + lookup.serialize(), getMetadata());
+        if(!Item.isNumeric(lookup))
+            throw new UnexpectedTypeException("Non numeric array lookup for " + lookup.serialize(), getMetadata());
+        this._lookup = Item.getNumericValue(lookup, Integer.class);
+        this._children.get(0).close();
+        this._children.get(1).close();
+        //-1 for Jsoniq convetion, arrays start from 1
+        this.result =_array.getItemAt(_lookup - 1);
+        this._hasNext = true;
+    }
+
+    private Item result;
     private ArrayItem _array;
     private int _lookup;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ArrayLookupIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ArrayLookupIterator.java
@@ -17,7 +17,7 @@
  * Author: Stefan Irimescu
  *
  */
- package sparksoniq.jsoniq.runtime.iterator.postfix;
+package sparksoniq.jsoniq.runtime.iterator.postfix;
 
 import sparksoniq.exceptions.InvalidSelectorException;
 import sparksoniq.exceptions.UnexpectedTypeException;
@@ -30,6 +30,11 @@ import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.semantics.DynamicContext;
 
 public class ArrayLookupIterator extends LocalRuntimeIterator {
+
+    private Item result;
+    private ArrayItem _array;
+    private int _lookup;
+    
     public ArrayLookupIterator(RuntimeIterator array, RuntimeIterator iterator, IteratorMetadata iteratorMetadata) {
         super(null, iteratorMetadata);
         this._children.add(array);
@@ -56,20 +61,16 @@ public class ArrayLookupIterator extends LocalRuntimeIterator {
         this._children.get(1).open(_currentDynamicContext);
         this._array = (ArrayItem) this._children.get(0).next();
         Item lookup = this._children.get(1).next();
-        if(this._children.get(1).hasNext() || lookup.isObject() || lookup.isArray())
+        if (this._children.get(1).hasNext() || lookup.isObject() || lookup.isArray())
             throw new InvalidSelectorException("Type error; There is not exactly one supplied parameter for an array selector: "
                     + lookup.serialize(), getMetadata());
-        if(!Item.isNumeric(lookup))
+        if (!Item.isNumeric(lookup))
             throw new UnexpectedTypeException("Non numeric array lookup for " + lookup.serialize(), getMetadata());
         this._lookup = Item.getNumericValue(lookup, Integer.class);
         this._children.get(0).close();
         this._children.get(1).close();
         //-1 for Jsoniq convetion, arrays start from 1
-        this.result =_array.getItemAt(_lookup - 1);
+        this.result = _array.getItemAt(_lookup - 1);
         this._hasNext = true;
     }
-
-    private Item result;
-    private ArrayItem _array;
-    private int _lookup;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ArrayLookupIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ArrayLookupIterator.java
@@ -34,7 +34,7 @@ public class ArrayLookupIterator extends LocalRuntimeIterator {
     private Item result;
     private ArrayItem _array;
     private int _lookup;
-    
+
     public ArrayLookupIterator(RuntimeIterator array, RuntimeIterator iterator, IteratorMetadata iteratorMetadata) {
         super(null, iteratorMetadata);
         this._children.add(array);
@@ -52,10 +52,7 @@ public class ArrayLookupIterator extends LocalRuntimeIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         this._children.get(0).open(_currentDynamicContext);
         this._children.get(1).open(_currentDynamicContext);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ArrayUnboxingIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ArrayUnboxingIterator.java
@@ -17,7 +17,7 @@
  * Author: Stefan Irimescu
  *
  */
- package sparksoniq.jsoniq.runtime.iterator.postfix;
+package sparksoniq.jsoniq.runtime.iterator.postfix;
 
 import sparksoniq.jsoniq.item.ArrayItem;
 import sparksoniq.jsoniq.item.Item;
@@ -30,8 +30,13 @@ import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ArrayUnboxingItertor extends LocalRuntimeIterator {
-    public ArrayUnboxingItertor(RuntimeIterator arrayIterator, IteratorMetadata iteratorMetadata) {
+public class ArrayUnboxingIterator extends LocalRuntimeIterator {
+
+    private List<Item> results;
+    private ArrayItem _array = null;
+    private int _currentIndex = 0;
+    
+    public ArrayUnboxingIterator(RuntimeIterator arrayIterator, IteratorMetadata iteratorMetadata) {
         super(null, iteratorMetadata);
         this._children.add(arrayIterator);
     }
@@ -47,8 +52,7 @@ public class ArrayUnboxingItertor extends LocalRuntimeIterator {
     public Item next() {
         if (this.hasNext()) {
             return getResult();
-        }
-        else {
+        } else {
             throw new IteratorFlowException("Illegal next() call in Array Unboxing!", getMetadata());
         }
     }
@@ -80,8 +84,4 @@ public class ArrayUnboxingItertor extends LocalRuntimeIterator {
             this._hasNext = true;
         }
     }
-
-    private List<Item> results;
-    private ArrayItem _array = null;
-    private int _currentIndex = 0;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ArrayUnboxingIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ArrayUnboxingIterator.java
@@ -35,7 +35,7 @@ public class ArrayUnboxingIterator extends LocalRuntimeIterator {
     private List<Item> results;
     private ArrayItem _array = null;
     private int _currentIndex = 0;
-    
+
     public ArrayUnboxingIterator(RuntimeIterator arrayIterator, IteratorMetadata iteratorMetadata) {
         super(null, iteratorMetadata);
         this._children.add(arrayIterator);
@@ -65,10 +65,7 @@ public class ArrayUnboxingIterator extends LocalRuntimeIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
         this.results = new ArrayList<>();
 
         this._children.get(0).open(_currentDynamicContext);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ObjectLookupIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ObjectLookupIterator.java
@@ -49,17 +49,12 @@ public class ObjectLookupIterator extends LocalRuntimeIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this.isOpen())
-            throw new IteratorFlowException("Variable reference iterator already open", getMetadata());
-        this._currentDynamicContext = context;
+        super.open(context);
         this.results = new ArrayList<>();
         this._currentIndex = 0;
+
         this.items = getItemsFromIteratorWithCurrentContext(this._children.get(0));
-        if (this.items.size() == 0) {
-            this._hasNext = false;
-        } else {
-            this._hasNext = true;
-        }
+
         this._children.get(1).open(_currentDynamicContext);
         this._lookupKey = this._children.get(1).next();
         if (this._children.get(1).hasNext() || _lookupKey.isObject() || _lookupKey.isArray())
@@ -74,6 +69,12 @@ public class ObjectLookupIterator extends LocalRuntimeIterator {
                 ObjectItem objItem = (ObjectItem) i;
                 results.add(objItem.getItemByKey(((StringItem) _lookupKey).getStringValue()));
             }
+        }
+
+        if (results.size() == 0) {
+            this._hasNext = false;
+        } else {
+            this._hasNext = true;
         }
     }
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/PredicateIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/PredicateIterator.java
@@ -65,10 +65,7 @@ public class PredicateIterator extends LocalRuntimeIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         if (this._children.size() < 2) {
             throw new SparksoniqRuntimeException("Invalid Predicate! Must initialize filter before calling next");

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/PredicateIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/PredicateIterator.java
@@ -17,7 +17,7 @@
  * Author: Stefan Irimescu
  *
  */
- package sparksoniq.jsoniq.runtime.iterator.postfix;
+package sparksoniq.jsoniq.runtime.iterator.postfix;
 
 import sparksoniq.jsoniq.item.Item;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
@@ -31,6 +31,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class PredicateIterator extends LocalRuntimeIterator {
+
+    private List<Item> unfilteredSequence = null;
+    private List<Item> results = null;
+    private int _currentIndex = 0;
 
     public PredicateIterator(RuntimeIterator sequence, RuntimeIterator filterExpression, IteratorMetadata iteratorMetadata) {
         super(null, iteratorMetadata);
@@ -66,7 +70,7 @@ public class PredicateIterator extends LocalRuntimeIterator {
         this._isOpen = true;
         this._currentDynamicContext = context;
 
-        if(this._children.size() < 2) {
+        if (this._children.size() < 2) {
             throw new SparksoniqRuntimeException("Invalid Predicate! Must initialize filter before calling next");
         }
 
@@ -80,7 +84,7 @@ public class PredicateIterator extends LocalRuntimeIterator {
         // get filtered list
         results = new ArrayList<>();
         RuntimeIterator filter = this._children.get(1);
-        for(Item item : unfilteredSequence){
+        for (Item item : unfilteredSequence) {
             //set the current item for the $$ children
             List<Item> currentItems = new ArrayList<>();
             currentItems.add(item);
@@ -99,9 +103,4 @@ public class PredicateIterator extends LocalRuntimeIterator {
             this._hasNext = true;
         }
     }
-
-    private List<Item> unfilteredSequence = null;
-    private List<Item> results = null;
-    private int _currentIndex = 0;
-
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ArrayRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ArrayRuntimeIterator.java
@@ -17,7 +17,7 @@
  * Author: Stefan Irimescu
  *
  */
- package sparksoniq.jsoniq.runtime.iterator.primary;
+package sparksoniq.jsoniq.runtime.iterator.primary;
 
 import sparksoniq.jsoniq.item.ArrayItem;
 import sparksoniq.jsoniq.item.Item;
@@ -34,9 +34,11 @@ import java.util.List;
 
 public class ArrayRuntimeIterator extends LocalRuntimeIterator {
 
+    private ArrayItem result;
+
     public ArrayRuntimeIterator(RuntimeIterator arrayItems, IteratorMetadata iteratorMetadata) {
         super(new ArrayList<>(), iteratorMetadata);
-        if(arrayItems!=null)
+        if (arrayItems != null)
             this._children.add(arrayItems);
     }
 
@@ -45,8 +47,7 @@ public class ArrayRuntimeIterator extends LocalRuntimeIterator {
         if (this.hasNext()) {
             this._hasNext = false;
             return result;
-        }
-        else throw new IteratorFlowException("Invalid next() call on array iterator", getMetadata());
+        } else throw new IteratorFlowException("Invalid next() call on array iterator", getMetadata());
     }
 
     @Override
@@ -60,6 +61,4 @@ public class ArrayRuntimeIterator extends LocalRuntimeIterator {
         this.result = new ArrayItem(result, ItemMetadata.fromIteratorMetadata(getMetadata()));
         this._hasNext = true;
     }
-
-    private ArrayItem result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ArrayRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ArrayRuntimeIterator.java
@@ -52,10 +52,7 @@ public class ArrayRuntimeIterator extends LocalRuntimeIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         List<Item> result = this.runChildrenIterators(this._currentDynamicContext);
         this.result = new ArrayItem(result, ItemMetadata.fromIteratorMetadata(getMetadata()));

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ArrayRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ArrayRuntimeIterator.java
@@ -26,7 +26,9 @@ import sparksoniq.jsoniq.runtime.iterator.LocalRuntimeIterator;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -40,14 +42,24 @@ public class ArrayRuntimeIterator extends LocalRuntimeIterator {
 
     @Override
     public ArrayItem next() {
-        if(this._hasNext) {
-            List<Item> result = this.runChildrenIterators(this._currentDynamicContext);
-            this._item = new ArrayItem(result, ItemMetadata.fromIteratorMetadata(getMetadata()));
+        if (this.hasNext()) {
             this._hasNext = false;
-            return _item;
+            return result;
         }
         else throw new IteratorFlowException("Invalid next() call on array iterator", getMetadata());
     }
 
-    private ArrayItem _item = null;
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
+
+        List<Item> result = this.runChildrenIterators(this._currentDynamicContext);
+        this.result = new ArrayItem(result, ItemMetadata.fromIteratorMetadata(getMetadata()));
+        this._hasNext = true;
+    }
+
+    private ArrayItem result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/AtomicRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/AtomicRuntimeIterator.java
@@ -17,7 +17,7 @@
  * Author: Stefan Irimescu
  *
  */
- package sparksoniq.jsoniq.runtime.iterator.primary;
+package sparksoniq.jsoniq.runtime.iterator.primary;
 
 import sparksoniq.jsoniq.item.AtomicItem;
 import sparksoniq.jsoniq.runtime.iterator.LocalRuntimeIterator;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/BooleanRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/BooleanRuntimeIterator.java
@@ -24,24 +24,35 @@ import sparksoniq.jsoniq.item.BooleanItem;
 import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 public class BooleanRuntimeIterator extends AtomicRuntimeIterator {
-    @Override
-    public BooleanItem next() {
-        if (this._hasNext) {
-            this._hasNext = false;
-            return new BooleanItem(_item, ItemMetadata.fromIteratorMetadata(getMetadata()));
-        }
-
-        throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + this._item, getMetadata());
-    }
-
     public BooleanRuntimeIterator(boolean value, IteratorMetadata iteratorMetadata) {
         super(null, iteratorMetadata);
-        this._item = value;
-
+        this._value = value;
     }
 
-    private boolean _item;
+    @Override
+    public BooleanItem next() {
+        if (this.hasNext()) {
+            this._hasNext = false;
+            return result;
+        }
+        throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + this._value, getMetadata());
+    }
+
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
+
+        this.result = new BooleanItem(_value, ItemMetadata.fromIteratorMetadata(getMetadata()));
+        this._hasNext = true;
+    }
+
+    private BooleanItem result;
+    private boolean _value;
 }
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/BooleanRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/BooleanRuntimeIterator.java
@@ -27,6 +27,10 @@ import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.semantics.DynamicContext;
 
 public class BooleanRuntimeIterator extends AtomicRuntimeIterator {
+
+    private BooleanItem result;
+    private boolean _value;
+
     public BooleanRuntimeIterator(boolean value, IteratorMetadata iteratorMetadata) {
         super(null, iteratorMetadata);
         this._value = value;
@@ -51,8 +55,5 @@ public class BooleanRuntimeIterator extends AtomicRuntimeIterator {
         this.result = new BooleanItem(_value, ItemMetadata.fromIteratorMetadata(getMetadata()));
         this._hasNext = true;
     }
-
-    private BooleanItem result;
-    private boolean _value;
 }
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/BooleanRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/BooleanRuntimeIterator.java
@@ -47,10 +47,7 @@ public class BooleanRuntimeIterator extends AtomicRuntimeIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         this.result = new BooleanItem(_value, ItemMetadata.fromIteratorMetadata(getMetadata()));
         this._hasNext = true;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ContextExpressionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ContextExpressionIterator.java
@@ -17,12 +17,13 @@
  * Author: Stefan Irimescu
  *
  */
- package sparksoniq.jsoniq.runtime.iterator.primary;
+package sparksoniq.jsoniq.runtime.iterator.primary;
 
 import sparksoniq.jsoniq.item.Item;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.jsoniq.runtime.iterator.LocalRuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,16 +35,23 @@ public class ContextExpressionIterator extends LocalRuntimeIterator {
 
     @Override
     public Item next() {
-        if(hasNext()){
+        if (this.hasNext()) {
             this._hasNext = false;
-            List<Item> results = new ArrayList<>();
-            if(results.size() > 1)
-                throw new IteratorFlowException("Invalid context item expression", getMetadata());
-            return _currentDynamicContext.getVariableValue("$$").get(0);
+            return result;
         }
-            throw new IteratorFlowException("Invalid next() call in Context Expression!", getMetadata());
+        throw new IteratorFlowException("Invalid next() call in Context Expression!", getMetadata());
     }
 
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
 
+        this.result = _currentDynamicContext.getVariableValue("$$").get(0);
+        this._hasNext = true;
+    }
 
+    private Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ContextExpressionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ContextExpressionIterator.java
@@ -47,10 +47,7 @@ public class ContextExpressionIterator extends LocalRuntimeIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         this.result = _currentDynamicContext.getVariableValue("$$").get(0);
         this._hasNext = true;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ContextExpressionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ContextExpressionIterator.java
@@ -29,6 +29,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class ContextExpressionIterator extends LocalRuntimeIterator {
+
+    private Item result;
+
     public ContextExpressionIterator(IteratorMetadata iteratorMetadata) {
         super(null, iteratorMetadata);
     }
@@ -52,6 +55,4 @@ public class ContextExpressionIterator extends LocalRuntimeIterator {
         this.result = _currentDynamicContext.getVariableValue("$$").get(0);
         this._hasNext = true;
     }
-
-    private Item result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/DecimalRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/DecimalRuntimeIterator.java
@@ -49,10 +49,7 @@ public class DecimalRuntimeIterator extends AtomicRuntimeIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         this.result = new DecimalItem(_value, ItemMetadata.fromIteratorMetadata(getMetadata()));
         this._hasNext = true;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/DecimalRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/DecimalRuntimeIterator.java
@@ -17,7 +17,7 @@
  * Author: Stefan Irimescu
  *
  */
- package sparksoniq.jsoniq.runtime.iterator.primary;
+package sparksoniq.jsoniq.runtime.iterator.primary;
 
 import sparksoniq.jsoniq.item.DecimalItem;
 import sparksoniq.jsoniq.item.metadata.ItemMetadata;
@@ -29,6 +29,10 @@ import sparksoniq.semantics.DynamicContext;
 import java.math.BigDecimal;
 
 public class DecimalRuntimeIterator extends AtomicRuntimeIterator {
+
+    private DecimalItem result;
+    private BigDecimal _value;
+
     public DecimalRuntimeIterator(BigDecimal value, IteratorMetadata iteratorMetadata) {
         super(null, iteratorMetadata);
         this._value = value;
@@ -43,8 +47,6 @@ public class DecimalRuntimeIterator extends AtomicRuntimeIterator {
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + this._value, getMetadata());
     }
 
-
-
     @Override
     public void open(DynamicContext context) {
         if (this._isOpen)
@@ -55,7 +57,4 @@ public class DecimalRuntimeIterator extends AtomicRuntimeIterator {
         this.result = new DecimalItem(_value, ItemMetadata.fromIteratorMetadata(getMetadata()));
         this._hasNext = true;
     }
-
-    private DecimalItem result;
-    private BigDecimal _value;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/DecimalRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/DecimalRuntimeIterator.java
@@ -24,26 +24,38 @@ import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import java.math.BigDecimal;
 
 public class DecimalRuntimeIterator extends AtomicRuntimeIterator {
+    public DecimalRuntimeIterator(BigDecimal value, IteratorMetadata iteratorMetadata) {
+        super(null, iteratorMetadata);
+        this._value = value;
+    }
 
     @Override
     public DecimalItem next() {
-        if (this._hasNext) {
+        if (this.hasNext()) {
             this._hasNext = false;
-            return new DecimalItem(_item, ItemMetadata.fromIteratorMetadata(getMetadata()));
+            return result;
         }
-
-        throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + this._item, getMetadata());
+        throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + this._value, getMetadata());
     }
 
-    public DecimalRuntimeIterator(BigDecimal value, IteratorMetadata iteratorMetadata) {
-        super(null, iteratorMetadata);
-        this._item = value;
 
+
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
+
+        this.result = new DecimalItem(_value, ItemMetadata.fromIteratorMetadata(getMetadata()));
+        this._hasNext = true;
     }
 
-    private BigDecimal _item;
+    private DecimalItem result;
+    private BigDecimal _value;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/DoubleRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/DoubleRuntimeIterator.java
@@ -47,10 +47,7 @@ public class DoubleRuntimeIterator extends AtomicRuntimeIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         this.result = new DoubleItem(_value, ItemMetadata.fromIteratorMetadata(getMetadata()));
         this._hasNext = true;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/DoubleRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/DoubleRuntimeIterator.java
@@ -17,7 +17,7 @@
  * Author: Stefan Irimescu
  *
  */
- package sparksoniq.jsoniq.runtime.iterator.primary;
+package sparksoniq.jsoniq.runtime.iterator.primary;
 
 import sparksoniq.jsoniq.item.DoubleItem;
 import sparksoniq.jsoniq.item.metadata.ItemMetadata;
@@ -26,11 +26,14 @@ import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.semantics.DynamicContext;
 
-public class DoubleRuntimeIterator extends AtomicRuntimeIterator{
+public class DoubleRuntimeIterator extends AtomicRuntimeIterator {
+
+    private DoubleItem result;
+    private double _value;
+
     public DoubleRuntimeIterator(Double value, IteratorMetadata iteratorMetadata) {
         super(null, iteratorMetadata);
         this._value = value;
-
     }
 
     @Override
@@ -42,7 +45,6 @@ public class DoubleRuntimeIterator extends AtomicRuntimeIterator{
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + this._value, getMetadata());
     }
 
-
     @Override
     public void open(DynamicContext context) {
         if (this._isOpen)
@@ -53,7 +55,4 @@ public class DoubleRuntimeIterator extends AtomicRuntimeIterator{
         this.result = new DoubleItem(_value, ItemMetadata.fromIteratorMetadata(getMetadata()));
         this._hasNext = true;
     }
-
-    private DoubleItem result;
-    private double _value;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/DoubleRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/DoubleRuntimeIterator.java
@@ -24,24 +24,36 @@ import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 public class DoubleRuntimeIterator extends AtomicRuntimeIterator{
+    public DoubleRuntimeIterator(Double value, IteratorMetadata iteratorMetadata) {
+        super(null, iteratorMetadata);
+        this._value = value;
+
+    }
 
     @Override
     public DoubleItem next() {
-        if (this._hasNext) {
+        if (this.hasNext()) {
             this._hasNext = false;
-            return new DoubleItem(_item, ItemMetadata.fromIteratorMetadata(getMetadata()));
+            return result;
         }
-
-        throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + this._item, getMetadata());
+        throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + this._value, getMetadata());
     }
 
-    public DoubleRuntimeIterator(Double value, IteratorMetadata iteratorMetadata) {
-        super(null, iteratorMetadata);
-        this._item = value;
 
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
+
+        this.result = new DoubleItem(_value, ItemMetadata.fromIteratorMetadata(getMetadata()));
+        this._hasNext = true;
     }
 
-    private double _item;
+    private DoubleItem result;
+    private double _value;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/IntegerRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/IntegerRuntimeIterator.java
@@ -27,10 +27,13 @@ import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.semantics.DynamicContext;
 
 public class IntegerRuntimeIterator extends AtomicRuntimeIterator {
+
+    private IntegerItem result;
+    private int _item;
+
     public IntegerRuntimeIterator(int value, IteratorMetadata iteratorMetadata) {
         super(null, iteratorMetadata);
         this._item = value;
-
     }
 
     @Override
@@ -52,7 +55,4 @@ public class IntegerRuntimeIterator extends AtomicRuntimeIterator {
         this.result = new IntegerItem(_item, ItemMetadata.fromIteratorMetadata(getMetadata()));
         this._hasNext = true;
     }
-
-    private IntegerItem result;
-    private int _item;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/IntegerRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/IntegerRuntimeIterator.java
@@ -17,31 +17,42 @@
  * Author: Stefan Irimescu
  *
  */
- package sparksoniq.jsoniq.runtime.iterator.primary;
+package sparksoniq.jsoniq.runtime.iterator.primary;
 
 import sparksoniq.jsoniq.item.IntegerItem;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 public class IntegerRuntimeIterator extends AtomicRuntimeIterator {
-
-    @Override
-    public IntegerItem next() {
-        if (this._hasNext) {
-            this._hasNext = false;
-            return new IntegerItem(_item, ItemMetadata.fromIteratorMetadata(getMetadata()));
-        }
-
-        throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + this._item, getMetadata());
-    }
-
     public IntegerRuntimeIterator(int value, IteratorMetadata iteratorMetadata) {
         super(null, iteratorMetadata);
         this._item = value;
 
     }
 
+    @Override
+    public IntegerItem next() {
+        if (this.hasNext()) {
+            this._hasNext = false;
+            return result;
+        }
+        throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + this._item, getMetadata());
+    }
+
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
+
+        this.result = new IntegerItem(_item, ItemMetadata.fromIteratorMetadata(getMetadata()));
+        this._hasNext = true;
+    }
+
+    private IntegerItem result;
     private int _item;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/IntegerRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/IntegerRuntimeIterator.java
@@ -47,10 +47,7 @@ public class IntegerRuntimeIterator extends AtomicRuntimeIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         this.result = new IntegerItem(_item, ItemMetadata.fromIteratorMetadata(getMetadata()));
         this._hasNext = true;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/NullRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/NullRuntimeIterator.java
@@ -46,10 +46,7 @@ public class NullRuntimeIterator extends AtomicRuntimeIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         this.result = new NullItem(ItemMetadata.fromIteratorMetadata(getMetadata()));
         this._hasNext = true;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/NullRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/NullRuntimeIterator.java
@@ -25,6 +25,7 @@ import sparksoniq.jsoniq.item.NullItem;
 import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 public class NullRuntimeIterator extends AtomicRuntimeIterator {
 
@@ -34,10 +35,23 @@ public class NullRuntimeIterator extends AtomicRuntimeIterator {
 
     @Override
     public AtomicItem next() {
-        if (this._hasNext) {
+        if (this.hasNext()) {
             this._hasNext = false;
-            return new NullItem(ItemMetadata.fromIteratorMetadata(getMetadata()));
+            return result;
         }
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + "\"null\"", getMetadata());
     }
+
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
+
+        this.result =  new NullItem(ItemMetadata.fromIteratorMetadata(getMetadata()));
+        this._hasNext = true;
+    }
+
+    private AtomicItem result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/NullRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/NullRuntimeIterator.java
@@ -17,7 +17,7 @@
  * Author: Stefan Irimescu
  *
  */
- package sparksoniq.jsoniq.runtime.iterator.primary;
+package sparksoniq.jsoniq.runtime.iterator.primary;
 
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.jsoniq.item.AtomicItem;
@@ -28,6 +28,8 @@ import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.semantics.DynamicContext;
 
 public class NullRuntimeIterator extends AtomicRuntimeIterator {
+
+    private AtomicItem result;
 
     public NullRuntimeIterator(IteratorMetadata iteratorMetadata) {
         super(null, iteratorMetadata);
@@ -49,9 +51,7 @@ public class NullRuntimeIterator extends AtomicRuntimeIterator {
         this._isOpen = true;
         this._currentDynamicContext = context;
 
-        this.result =  new NullItem(ItemMetadata.fromIteratorMetadata(getMetadata()));
+        this.result = new NullItem(ItemMetadata.fromIteratorMetadata(getMetadata()));
         this._hasNext = true;
     }
-
-    private AtomicItem result;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ObjectConstructorRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ObjectConstructorRuntimeIterator.java
@@ -39,7 +39,7 @@ public class ObjectConstructorRuntimeIterator extends LocalRuntimeIterator {
     private List<RuntimeIterator> _keys;
     private List<RuntimeIterator> _values;
     private boolean _isMergedObject = false;
-    
+
     public ObjectConstructorRuntimeIterator(List<RuntimeIterator> keys, List<RuntimeIterator> values,
                                             IteratorMetadata iteratorMetadata) {
         super(keys, iteratorMetadata);
@@ -66,10 +66,7 @@ public class ObjectConstructorRuntimeIterator extends LocalRuntimeIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         List<Item> values = new ArrayList<>();
         List<String> keys = new ArrayList<>();

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ObjectConstructorRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ObjectConstructorRuntimeIterator.java
@@ -34,6 +34,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class ObjectConstructorRuntimeIterator extends LocalRuntimeIterator {
+
+    private ObjectItem result;
+    private List<RuntimeIterator> _keys;
+    private List<RuntimeIterator> _values;
+    private boolean _isMergedObject = false;
+    
     public ObjectConstructorRuntimeIterator(List<RuntimeIterator> keys, List<RuntimeIterator> values,
                                             IteratorMetadata iteratorMetadata) {
         super(keys, iteratorMetadata);
@@ -109,9 +115,4 @@ public class ObjectConstructorRuntimeIterator extends LocalRuntimeIterator {
         }
         this._hasNext = true;
     }
-
-    private ObjectItem result;
-    private List<RuntimeIterator> _keys;
-    private List<RuntimeIterator> _values;
-    private boolean _isMergedObject = false;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ObjectConstructorRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ObjectConstructorRuntimeIterator.java
@@ -28,12 +28,12 @@ import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.LocalRuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class ObjectConstructorRuntimeIterator extends LocalRuntimeIterator {
-
     public ObjectConstructorRuntimeIterator(List<RuntimeIterator> keys, List<RuntimeIterator> values,
                                             IteratorMetadata iteratorMetadata) {
         super(keys, iteratorMetadata);
@@ -41,7 +41,6 @@ public class ObjectConstructorRuntimeIterator extends LocalRuntimeIterator {
         this._keys = keys;
         this._values = values;
     }
-
 
     public ObjectConstructorRuntimeIterator(List<ObjectConstructorRuntimeIterator> childExpressions,
                                             IteratorMetadata iteratorMetadata) {
@@ -52,55 +51,66 @@ public class ObjectConstructorRuntimeIterator extends LocalRuntimeIterator {
 
     @Override
     public ObjectItem next() {
-        if (this._hasNext) {
-            List<Item> values = new ArrayList<>();
-            List<String> keys = new ArrayList<>();
-            if (_isMergedObject) {
-                for (RuntimeIterator iterator : this._children) {
-                    iterator.open(_currentDynamicContext);
-                    ObjectItem item = (ObjectItem) iterator.next();
-                    iterator.close();
-                    keys.addAll(item.getKeys());
-                    values.addAll(item.getValues());
-                }
-                this._hasNext = false;
-                return new ObjectItem(keys, values, ItemMetadata.fromIteratorMetadata(getMetadata()));
-
-            } else {
-
-                for (RuntimeIterator valueIterator : this._values) {
-                    List<Item> currentResults = new ArrayList<>();
-                    valueIterator.open(this._currentDynamicContext);
-                    while (valueIterator.hasNext())
-                        currentResults.add(valueIterator.next());
-//                    if(valueIterator.hasNext())
-//                        throw new IteratorFlowException("Object value must return one item!");
-                    valueIterator.close();
-                    //SIMILAR TO ZORBA, if value is more than one item, wrap it in an array
-                    if (currentResults.size() > 1)
-                        values.add(new ArrayItem(currentResults, ItemMetadata.fromIteratorMetadata(getMetadata())));
-                    else
-                        values.add(currentResults.get(0));
-                }
-
-                for (RuntimeIterator keyIterator : this._keys) {
-                    keyIterator.open(this._currentDynamicContext);
-                    try {
-                        keys.add(((StringItem) keyIterator.next()).getStringValue());
-                    } catch (Exception ex) {
-                        throw new IteratorFlowException("Object must have string keys!", getMetadata());
-                    }
-                    if (keyIterator.hasNext())
-                        throw new IteratorFlowException("Object value must return one item!", getMetadata());
-                    keyIterator.close();
-                }
-                this._hasNext = false;
-                return new ObjectItem(keys, values, ItemMetadata.fromIteratorMetadata(getMetadata()));
-            }
+        if (this.hasNext()) {
+            this._hasNext = false;
+            return result;
         }
         throw new IteratorFlowException("Invalid next() call on object!", getMetadata());
     }
 
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
+
+        List<Item> values = new ArrayList<>();
+        List<String> keys = new ArrayList<>();
+        if (_isMergedObject) {
+            for (RuntimeIterator iterator : this._children) {
+                iterator.open(_currentDynamicContext);
+                ObjectItem item = (ObjectItem) iterator.next();
+                iterator.close();
+                keys.addAll(item.getKeys());
+                values.addAll(item.getValues());
+            }
+            this.result = new ObjectItem(keys, values, ItemMetadata.fromIteratorMetadata(getMetadata()));
+
+        } else {
+
+            for (RuntimeIterator valueIterator : this._values) {
+                List<Item> currentResults = new ArrayList<>();
+                valueIterator.open(this._currentDynamicContext);
+                while (valueIterator.hasNext())
+                    currentResults.add(valueIterator.next());
+//                    if(valueIterator.hasNext())
+//                        throw new IteratorFlowException("Object value must return one item!");
+                valueIterator.close();
+                //SIMILAR TO ZORBA, if value is more than one item, wrap it in an array
+                if (currentResults.size() > 1)
+                    values.add(new ArrayItem(currentResults, ItemMetadata.fromIteratorMetadata(getMetadata())));
+                else
+                    values.add(currentResults.get(0));
+            }
+
+            for (RuntimeIterator keyIterator : this._keys) {
+                keyIterator.open(this._currentDynamicContext);
+                try {
+                    keys.add(((StringItem) keyIterator.next()).getStringValue());
+                } catch (Exception ex) {
+                    throw new IteratorFlowException("Object must have string keys!", getMetadata());
+                }
+                if (keyIterator.hasNext())
+                    throw new IteratorFlowException("Object value must return one item!", getMetadata());
+                keyIterator.close();
+            }
+            this.result = new ObjectItem(keys, values, ItemMetadata.fromIteratorMetadata(getMetadata()));
+        }
+        this._hasNext = true;
+    }
+
+    private ObjectItem result;
     private List<RuntimeIterator> _keys;
     private List<RuntimeIterator> _values;
     private boolean _isMergedObject = false;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/StringRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/StringRuntimeIterator.java
@@ -24,24 +24,34 @@ import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 public class StringRuntimeIterator extends AtomicRuntimeIterator {
+    public StringRuntimeIterator(String value, IteratorMetadata iteratorMetadata) {
+        super(null, iteratorMetadata);
+        this._value = value;
+    }
 
     @Override
     public StringItem next() {
-        if (this._hasNext) {
+        if (this.hasNext()) {
             this._hasNext = false;
-            return new StringItem(_item, ItemMetadata.fromIteratorMetadata(getMetadata()));
+            return result;
         }
-
-        throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + this._item, getMetadata());
+        throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + this._value, getMetadata());
     }
 
-    public StringRuntimeIterator(String value, IteratorMetadata iteratorMetadata) {
-        super(null, iteratorMetadata);
-        this._item = value;
+    @Override
+    public void open(DynamicContext context) {
+        if (this._isOpen)
+            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
+        this._isOpen = true;
+        this._currentDynamicContext = context;
 
+        this.result = new StringItem(_value, ItemMetadata.fromIteratorMetadata(getMetadata()));
+        this._hasNext = true;
     }
 
-    private String _item;
+    private StringItem result;
+    private String _value;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/StringRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/StringRuntimeIterator.java
@@ -47,10 +47,7 @@ public class StringRuntimeIterator extends AtomicRuntimeIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         this.result = new StringItem(_value, ItemMetadata.fromIteratorMetadata(getMetadata()));
         this._hasNext = true;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/StringRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/StringRuntimeIterator.java
@@ -17,7 +17,7 @@
  * Author: Stefan Irimescu
  *
  */
- package sparksoniq.jsoniq.runtime.iterator.primary;
+package sparksoniq.jsoniq.runtime.iterator.primary;
 
 import sparksoniq.jsoniq.item.StringItem;
 import sparksoniq.jsoniq.item.metadata.ItemMetadata;
@@ -27,6 +27,10 @@ import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.semantics.DynamicContext;
 
 public class StringRuntimeIterator extends AtomicRuntimeIterator {
+
+    private StringItem result;
+    private String _value;
+
     public StringRuntimeIterator(String value, IteratorMetadata iteratorMetadata) {
         super(null, iteratorMetadata);
         this._value = value;
@@ -51,7 +55,4 @@ public class StringRuntimeIterator extends AtomicRuntimeIterator {
         this.result = new StringItem(_value, ItemMetadata.fromIteratorMetadata(getMetadata()));
         this._hasNext = true;
     }
-
-    private StringItem result;
-    private String _value;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/VariableReferenceIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/VariableReferenceIterator.java
@@ -70,10 +70,9 @@ public class VariableReferenceIterator extends LocalRuntimeIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this.isOpen())
-            throw new IteratorFlowException("Variable reference iterator already open", getMetadata());
-        this._currentDynamicContext = context;
+        super.open(context);
         this.currentIndex = 0;
+
         this.items = this._currentDynamicContext.getVariableValue(this._variableName);
         if (items.size() == 0) {
             this._hasNext = false;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/VariableReferenceIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/VariableReferenceIterator.java
@@ -17,7 +17,7 @@
  * Author: Stefan Irimescu
  *
  */
- package sparksoniq.jsoniq.runtime.iterator.primary;
+package sparksoniq.jsoniq.runtime.iterator.primary;
 
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.semantics.DynamicContext;
@@ -31,6 +31,19 @@ import java.util.List;
 
 public class VariableReferenceIterator extends LocalRuntimeIterator {
 
+    private SequenceType sequence;
+    private String _variableName;
+    private List<Item> items = null;
+    private int currentIndex = 0;
+
+    public SequenceType getSequence() {
+        return sequence;
+    }
+
+    public String getVariableName() {
+        return _variableName;
+    }
+
     public VariableReferenceIterator(String variableName, SequenceType seq, IteratorMetadata iteratorMetadata) {
         super(null, iteratorMetadata);
         this._variableName = "$" + variableName;
@@ -39,48 +52,33 @@ public class VariableReferenceIterator extends LocalRuntimeIterator {
 
     @Override
     public Item next() {
-        if(!this.hasNext())
+        if (!this.hasNext())
             throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + "$" + _variableName, getMetadata());
         Item item = items.get(currentIndex);
         currentIndex++;
-        if(currentIndex == items.size())
+        if (currentIndex == items.size())
             this._hasNext = false;
         return item;
     }
 
     @Override
-    public void reset(DynamicContext context){
+    public void reset(DynamicContext context) {
         super.reset(context);
         this.currentIndex = 0;
         this.items = null;
     }
 
     @Override
-    public void open(DynamicContext context){
-        if(this.isOpen())
+    public void open(DynamicContext context) {
+        if (this.isOpen())
             throw new IteratorFlowException("Variable reference iterator already open", getMetadata());
         this._currentDynamicContext = context;
         this.currentIndex = 0;
         this.items = this._currentDynamicContext.getVariableValue(this._variableName);
-        if(items.size() == 0) {
+        if (items.size() == 0) {
             this._hasNext = false;
-        }
-        else {
+        } else {
             this._hasNext = true;
         }
     }
-
-    public SequenceType getSequence() {
-        return sequence;
-    }
-
-
-    public String getVariableName() {
-        return _variableName;
-    }
-
-    private SequenceType sequence;
-    private String _variableName;
-    private List<Item> items = null;
-    private int currentIndex  = 0;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/quantifiers/QuantifiedExpressionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/quantifiers/QuantifiedExpressionIterator.java
@@ -59,10 +59,7 @@ public class QuantifiedExpressionIterator extends LocalRuntimeIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         List<DynamicContext> contexts = new ArrayList<>();
         contexts.add(new DynamicContext(_currentDynamicContext));

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/quantifiers/QuantifiedExpressionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/quantifiers/QuantifiedExpressionIterator.java
@@ -34,6 +34,10 @@ import java.util.List;
 
 public class QuantifiedExpressionIterator extends LocalRuntimeIterator {
 
+    private Item result;
+    private final QuantifiedExpression.QuantifiedOperators _operator;
+    private final RuntimeIterator _evaluationExpression;
+
     public QuantifiedExpressionIterator(QuantifiedExpression.QuantifiedOperators operator,
                                         List<QuantifiedExpressionVarIterator> children,
                                         RuntimeIterator evaluationExpression, IteratorMetadata iteratorMetadata) {
@@ -105,9 +109,4 @@ public class QuantifiedExpressionIterator extends LocalRuntimeIterator {
         }
         return results;
     }
-
-    private Item result;
-    private final QuantifiedExpression.QuantifiedOperators _operator;
-    private final RuntimeIterator _evaluationExpression;
-
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/quantifiers/QuantifiedExpressionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/quantifiers/QuantifiedExpressionIterator.java
@@ -91,7 +91,6 @@ public class QuantifiedExpressionIterator extends LocalRuntimeIterator {
         List<DynamicContext> results = new ArrayList<>();
         for (DynamicContext currentContext : previousContexts) {
             var.open(currentContext);
-            var.reset(currentContext);
             while (var.hasNext()) {
                 DynamicContext context = new DynamicContext(currentContext);
                 List<Item> contents = new ArrayList<>();

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/quantifiers/QuantifiedExpressionVarIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/quantifiers/QuantifiedExpressionVarIterator.java
@@ -17,7 +17,7 @@
  * Author: Stefan Irimescu
  *
  */
- package sparksoniq.jsoniq.runtime.iterator.quantifiers;
+package sparksoniq.jsoniq.runtime.iterator.quantifiers;
 
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.jsoniq.item.Item;
@@ -32,6 +32,10 @@ import java.util.List;
 
 public class QuantifiedExpressionVarIterator extends LocalRuntimeIterator {
 
+    private List<Item> results;
+    private int _currentIndex;
+    private final String _variableReference;
+    private final SequenceType _sequenceType;
 
     public String getVariableReference() {
         return _variableReference;
@@ -46,7 +50,7 @@ public class QuantifiedExpressionVarIterator extends LocalRuntimeIterator {
     }
 
     @Override
-    public void reset(DynamicContext context){
+    public void reset(DynamicContext context) {
         super.reset(context);
         this.results = null;
     }
@@ -86,10 +90,4 @@ public class QuantifiedExpressionVarIterator extends LocalRuntimeIterator {
             this._hasNext = true;
         }
     }
-
-    private List<Item> results;
-    private int _currentIndex;
-    private final String _variableReference;
-    private final SequenceType _sequenceType;
-
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/quantifiers/QuantifiedExpressionVarIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/quantifiers/QuantifiedExpressionVarIterator.java
@@ -71,10 +71,7 @@ public class QuantifiedExpressionVarIterator extends LocalRuntimeIterator {
 
     @Override
     public void open(DynamicContext context) {
-        if (this._isOpen)
-            throw new IteratorFlowException("Runtime iterator cannot be opened twice", getMetadata());
-        this._isOpen = true;
-        this._currentDynamicContext = context;
+        super.open(context);
 
         RuntimeIterator expression = this._children.get(0);
         results = new ArrayList<>();

--- a/src/main/java/sparksoniq/semantics/visitor/RuntimeIteratorVisitor.java
+++ b/src/main/java/sparksoniq/semantics/visitor/RuntimeIteratorVisitor.java
@@ -43,7 +43,7 @@ import sparksoniq.jsoniq.runtime.iterator.control.SwitchRuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.Functions;
 import sparksoniq.jsoniq.runtime.iterator.operational.*;
 import sparksoniq.jsoniq.runtime.iterator.postfix.ArrayLookupIterator;
-import sparksoniq.jsoniq.runtime.iterator.postfix.ArrayUnboxingItertor;
+import sparksoniq.jsoniq.runtime.iterator.postfix.ArrayUnboxingIterator;
 import sparksoniq.jsoniq.runtime.iterator.postfix.ObjectLookupIterator;
 import sparksoniq.jsoniq.runtime.iterator.postfix.PredicateIterator;
 import sparksoniq.jsoniq.runtime.iterator.primary.*;
@@ -169,7 +169,7 @@ public class RuntimeIteratorVisitor extends AbstractExpressionOrClauseVisitor<Ru
                         previous = new ObjectLookupIterator(previous, iterator, createIteratorMetadata(expression));
                     }
                     if (extension instanceof ArrayUnboxingExtension) {
-                        previous = new ArrayUnboxingItertor(previous, createIteratorMetadata(expression));
+                        previous = new ArrayUnboxingIterator(previous, createIteratorMetadata(expression));
                     }
                     if (extension instanceof PredicateExtension) {
                         RuntimeIterator filterExpression = //pass the predicate as argument for $$ expresions

--- a/src/main/java/sparksoniq/spark/iterator/function/SparkFunctionCallIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/function/SparkFunctionCallIterator.java
@@ -21,6 +21,7 @@
 
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 import sparksoniq.spark.iterator.SparkRuntimeIterator;
 
 import java.util.List;
@@ -28,5 +29,11 @@ import java.util.List;
 public abstract class SparkFunctionCallIterator extends SparkRuntimeIterator {
     protected SparkFunctionCallIterator(List<RuntimeIterator> parameters, IteratorMetadata iteratorMetadata) {
         super(parameters, iteratorMetadata);
+    }
+
+    @Override
+    public void open(DynamicContext context) {
+        super.open(context);
+        this._hasNext = true;
     }
 }

--- a/src/main/resources/test_files/runtime/Comparisons/ValueComparisonEmptySequence.iq
+++ b/src/main/resources/test_files/runtime/Comparisons/ValueComparisonEmptySequence.iq
@@ -1,9 +1,9 @@
-(:JIQS: ShouldRun; Output="( , , , , , , , )" :)
+(:JIQS: ShouldRun; Output="" :)
 () eq (),
 () ne 3,
 () lt (2,3),
 () gt (2.0, 3),
 () le (2e1, "ab"),
-() ge (2e-3, "1a")
-((),()) eq 2
+() ge (2e-3, "1a"),
+((),()) eq 2,
 2 lt ((),())

--- a/src/main/resources/test_files/runtime/PostFixArrayUnboxing/ArrayUnboxing1.iq
+++ b/src/main/resources/test_files/runtime/PostFixArrayUnboxing/ArrayUnboxing1.iq
@@ -1,0 +1,4 @@
+(:JIQS: ShouldRun; Output="( 1, 2)" :)
+[1, 2][]
+
+(: simple array :)

--- a/src/main/resources/test_files/runtime/PostFixArrayUnboxing/ArrayUnboxing2.iq
+++ b/src/main/resources/test_files/runtime/PostFixArrayUnboxing/ArrayUnboxing2.iq
@@ -1,2 +1,5 @@
 (:JIQS: ShouldRun; Output="( 1, 2, 3, 4, [ 5, 6 ])" :)
 [1, 2, 3, 4, [5,6]][]
+
+(: nested array :)
+

--- a/src/main/resources/test_files/runtime/PostFixArrayUnboxing/ArrayUnboxing3.iq
+++ b/src/main/resources/test_files/runtime/PostFixArrayUnboxing/ArrayUnboxing3.iq
@@ -1,0 +1,4 @@
+(:JIQS: ShouldRun; Output="" :)
+[][]
+
+(: empty array :)


### PR DESCRIPTION
**Second take** on the empty sequence problem:

First two commits fix the out of bounds and illegal next calling issues.

Last commit is experimental and fixes the nullpointer exceptions occurring in the spark framework. If result.iterator() contains null elements which means that the result of the query is an empty sequence, an exception is thrown. By removing the said null elements, no exceptions are met. However, I'm worried that this solution might be crude and there might be corner cases that I'm missing.

Following queries which provided the respective exceptions now work as intended and return empty sequences. Related tests are also added.

let $o := (()) return $o()
✔ [ERROR] Job aborted due to stage failure: ..... java.lang.IndexOutOfBoundsException:

let $o := (()) return size($o)
✔ [ERROR] Job aborted due to stage failure: ..... java.lang.IndexOutOfBoundsException:

let $o := (1, 2, "a", [], 5e+3) return descendant-objects($o)
✔ [ERROR] Job aborted due to stage failure: ..... java.lang.NullPointerException

let $o := ([]) return flatten($o)
✔ [ERROR] Job aborted due to stage failure: ..... java.lang.NullPointerException

let $o := ({}) return descendant-arrays($o)
✔ [ERROR] Job aborted due to stage failure: ..... java.lang.NullPointerException