### PR TITLE
Issue24 div

### DIFF
--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/MultiplicativeOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/MultiplicativeOperationIterator.java
@@ -68,7 +68,10 @@ public class MultiplicativeOperationIterator extends BinaryOperationBaseIterator
                         this.result = new IntegerItem(l * r, ItemMetadata.fromIteratorMetadata(getMetadata()));
                         break;
                     case DIV:
-                        this.result = new IntegerItem(l / r, ItemMetadata.fromIteratorMetadata(getMetadata()));
+                        BigDecimal decLeft = Item.<BigDecimal>getNumericValue(left, BigDecimal.class);
+                        BigDecimal decRight = Item.<BigDecimal>getNumericValue(right, BigDecimal.class);
+                        this.result = new DecimalItem(decLeft.divide(decRight, 10, BigDecimal.ROUND_HALF_UP),
+                                ItemMetadata.fromIteratorMetadata(getMetadata()));
                         break;
                     case MOD:
                         this.result = new IntegerItem(l % r, ItemMetadata.fromIteratorMetadata(getMetadata()));

--- a/src/main/resources/test_files/runtime/BasicIntegerArithmetic.iq
+++ b/src/main/resources/test_files/runtime/BasicIntegerArithmetic.iq
@@ -1,3 +1,3 @@
-(:JIQS: ShouldRun; Output="( 0, 8)" :)
+(:JIQS: ShouldRun; Output="( 0E-10, 8)" :)
 ---2 + 3 * 4 - 2 * 5 div 2 mod 6 * 2,
 1 * ( 2 + 3 ) + 7 idiv 2 - (-8) mod 2

--- a/src/main/resources/test_files/runtime/Parenthesized.iq
+++ b/src/main/resources/test_files/runtime/Parenthesized.iq
@@ -1,2 +1,2 @@
-(:JIQS: ShouldRun; Output="2" :)
+(:JIQS: ShouldRun; Output="2.6666666667" :)
 (2+3) * 4 div ((2*5) + 2) + 1


### PR DESCRIPTION
Div operation between two operations has been changed result in a decimal in order to preserve precision. 
4 div 3 returns 1.3333333333

Test files have been updated accordingly. I have one question though:
---2 + 3 * 4 - 2 * 5 div 2 mod 6 * 2
The expression above previously returned **0** (same result on Zorba), however, currently it returns **0E-10** due to the precision of Decimal type. These two values appear to be equal in Zorba, yet I was wondering if this change in output format is undesirable.