### PR TITLE
Array size itr

### DIFF
--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArraySizeFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArraySizeFunctionIterator.java
@@ -24,9 +24,11 @@ import sparksoniq.jsoniq.item.ArrayItem;
 import sparksoniq.jsoniq.item.IntegerItem;
 import sparksoniq.jsoniq.item.Item;
 import sparksoniq.jsoniq.item.metadata.ItemMetadata;
+import sparksoniq.jsoniq.runtime.iterator.EmptySequenceIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.LocalFunctionCallIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import java.util.List;
 
@@ -38,10 +40,24 @@ public class ArraySizeFunctionIterator extends ArrayFunctionIterator {
     }
 
     @Override
+    public void open(DynamicContext context) {
+        super.open(context);
+
+        arrayIterator = this._children.get(0);
+        arrayIterator.open(context);
+        if (arrayIterator.hasNext() == false) {
+            this._hasNext = false;
+        } else {
+            this._hasNext = true;
+        }
+        arrayIterator.close();
+    }
+
+    @Override
     public Item next() {
         if (this._hasNext) {
             this._hasNext = false;
-            RuntimeIterator arrayIterator = this._children.get(0);
+
             ArrayItem array = getSingleItemOfTypeFromIterator(arrayIterator, ArrayItem.class);
             return new IntegerItem(array.getSize(), ItemMetadata.fromIteratorMetadata(getMetadata()));
         }
@@ -49,4 +65,5 @@ public class ArraySizeFunctionIterator extends ArrayFunctionIterator {
                 getMetadata());
     }
 
+    private RuntimeIterator arrayIterator;
 }

--- a/src/main/resources/test_files/runtime/FunctionArray/FunctionArraySize.iq
+++ b/src/main/resources/test_files/runtime/FunctionArray/FunctionArraySize.iq
@@ -1,4 +1,6 @@
 (:JIQS: ShouldRun; Output="( 3, 0, 5)" :)
 size([1,2,3]),
 size([]),
-size([5,6,7,8,9])
+size([5,6,7,8,9]),
+size(()),
+size(((),()))


### PR DESCRIPTION
Lazy evaluation and empty sequence support added to array size iterator

PS: I'm purposefully adding the test cases such as ( (), () ) . It's semantically equivalent to an empty sequence however, it prevents the antipattern of checking for emptySequenceIterator. This test case enforces that we're checking the hasNext to be false rather than simply checking if iterator is an empty sequence iterator. If latter is done (()) would be handled successfully however since ( (), (), ) is a commaExpression at the higher level, emptySequence check would've failed. 