### PR TITLE
Descendant functions

### DIFF
--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArrayDescendantFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArrayDescendantFunctionIterator.java
@@ -1,54 +1,90 @@
 package sparksoniq.jsoniq.runtime.iterator.functions.arrays;
 
 import sparksoniq.exceptions.IteratorFlowException;
+import sparksoniq.jsoniq.item.ArrayItem;
 import sparksoniq.jsoniq.item.Item;
+import sparksoniq.jsoniq.item.ObjectItem;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import javax.naming.OperationNotSupportedException;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 
 public class ArrayDescendantFunctionIterator extends ArrayFunctionIterator {
+
+    private RuntimeIterator _iterator;
+    private Queue<Item> _nextResults;   // queue that holds the results created by the current item in inspection
+
+
     public ArrayDescendantFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, ArrayFunctionOperators.DESCENDANT, iteratorMetadata);
     }
 
     @Override
+    public void open(DynamicContext context) {
+        super.open(context);
+
+        _iterator = this._children.get(0);
+        _iterator.open(context);
+        _nextResults = new LinkedList<>();
+
+        setNextResult();
+    }
+
+    @Override
     public Item next() {
         if (this._hasNext) {
-            if (results == null) {
-                _currentIndex = 0;
-                results = new ArrayList<>();
-                RuntimeIterator sequenceIterator = this._children.get(0);
-                List<Item> items = getItemsFromIteratorWithCurrentContext(sequenceIterator);
-                getDescendantArrays(items);
+            Item result = _nextResults.remove();  // save the result to be returned
+            if (_nextResults.isEmpty()) {
+                // if there are no more results left in the queue, trigger calculation for the next result
+                setNextResult();
             }
-            return getResult();
+            return result;
         }
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " DESCENDANT-ARRAYS function",
                 getMetadata());
     }
 
+    public void setNextResult() {
+        while (_iterator.hasNext()) {
+            Item item = _iterator.next();
+            List<Item> singleItemList = new ArrayList<>();
+            singleItemList.add(item);
+
+            getDescendantArrays(singleItemList);
+            if (!(_nextResults.isEmpty())) {
+                break;
+            }
+
+        }
+
+        if (_nextResults.isEmpty()) {
+            this._hasNext = false;
+            _iterator.close();
+        } else {
+            this._hasNext = true;
+        }
+    }
+
     public void getDescendantArrays(List<Item> items) {
         for (Item item:items) {
-            if (item.isArray()) {
-                results.add(item);
-                try {
+            try {
+                if (item.isArray()) {
+                    _nextResults.add(item);
                     getDescendantArrays(item.getItems());
-                } catch (OperationNotSupportedException e) {
-                    e.printStackTrace();
-                }
-            }
-            else if (item.isObject()) {
-                try {
+                } else if (item.isObject()) {
                     getDescendantArrays((List<Item>) item.getValues());
-                } catch (OperationNotSupportedException e) {
-                    e.printStackTrace();
+                } else {
+                    // for atomic types: do nothing
                 }
-            }
-            else {
-                // do nothing
+            } catch (OperationNotSupportedException e) {
+                e.printStackTrace();
             }
         }
     }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectDescendantFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectDescendantFunctionIterator.java
@@ -1,56 +1,87 @@
 package sparksoniq.jsoniq.runtime.iterator.functions.object;
 
 import sparksoniq.exceptions.IteratorFlowException;
+import sparksoniq.jsoniq.item.ArrayItem;
 import sparksoniq.jsoniq.item.Item;
 import sparksoniq.jsoniq.item.ObjectItem;
 import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import javax.naming.OperationNotSupportedException;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Queue;
 
 public class ObjectDescendantFunctionIterator extends ObjectFunctionIterator {
+
+    private RuntimeIterator _iterator;
+    private Queue<Item> _nextResults;   // queue that holds the results created by the current item in inspection
+
     public ObjectDescendantFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, ObjectFunctionOperators.DESCENDANT, iteratorMetadata);
     }
 
     @Override
+    public void open(DynamicContext context) {
+        super.open(context);
+
+        _iterator = this._children.get(0);
+        _iterator.open(context);
+        _nextResults = new LinkedList<>();
+
+        setNextResult();
+    }
+
+    @Override
     public Item next() {
         if (this._hasNext) {
-            if (results == null) {
-                _currentIndex = 0;
-                results = new ArrayList<>();
-                RuntimeIterator sequenceIterator = this._children.get(0);
-                List<Item> items = getItemsFromIteratorWithCurrentContext(sequenceIterator);
-                getDescendantObjects(items);
+            Item result = _nextResults.remove();  // save the result to be returned
+            if (_nextResults.isEmpty()) {
+                // if there are no more results left in the queue, trigger calculation for the next result
+                setNextResult();
             }
-            return getResult();
+            return result;
         }
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " DESCENDANT-OBJECTS function",
                 getMetadata());
     }
 
+    public void setNextResult() {
+        while (_iterator.hasNext()) {
+            Item item = _iterator.next();
+            List<Item> singleItemList = new ArrayList<>();
+            singleItemList.add(item);
+
+            getDescendantObjects(singleItemList);
+            if (!(_nextResults.isEmpty())) {
+                break;
+            }
+        }
+
+        if (_nextResults.isEmpty()) {
+            this._hasNext = false;
+            _iterator.close();
+        } else {
+            this._hasNext = true;
+        }
+    }
+
     public void getDescendantObjects(List<Item> items) {
         for (Item item:items) {
-            if (item.isArray()) {
-                try {
+            try {
+                if (item.isArray()) {
                     getDescendantObjects(item.getItems());
-                } catch (OperationNotSupportedException e) {
-                    e.printStackTrace();
-                }
-            }
-            else if (item.isObject()) {
-                results.add(item);
-                try {
+                } else if (item.isObject()) {
+                    _nextResults.add(item);
                     getDescendantObjects((List<Item>) item.getValues());
-                } catch (OperationNotSupportedException e) {
-                    e.printStackTrace();
+                } else {
+                    // for atomic types: do nothing
                 }
-            }
-            else {
-                // do nothing
+            } catch (OperationNotSupportedException e) {
+                e.printStackTrace();
             }
         }
     }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectDescendantPairsFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectDescendantPairsFunctionIterator.java
@@ -6,61 +6,87 @@ import sparksoniq.jsoniq.item.ObjectItem;
 import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
 
 import javax.naming.OperationNotSupportedException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 public class ObjectDescendantPairsFunctionIterator extends ObjectFunctionIterator {
+
+    private RuntimeIterator _iterator;
+    private Queue<Item> _nextResults;   // queue that holds the results created by the current item in inspection
+
     public ObjectDescendantPairsFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
         super(arguments, ObjectFunctionOperators.DESCENDANTPAIRS, iteratorMetadata);
     }
 
     @Override
+    public void open(DynamicContext context) {
+        super.open(context);
+
+        _iterator = this._children.get(0);
+        _iterator.open(context);
+        _nextResults = new LinkedList<>();
+
+        setNextResult();
+    }
+
+    @Override
     public Item next() {
         if (this._hasNext) {
-            if (results == null) {
-                _currentIndex = 0;
-                results = new ArrayList<>();
-                RuntimeIterator sequenceIterator = this._children.get(0);
-                List<Item> items = getItemsFromIteratorWithCurrentContext(sequenceIterator);
-                getDescendantPairs(items);
+            Item result = _nextResults.remove();  // save the result to be returned
+            if (_nextResults.isEmpty()) {
+                // if there are no more results left in the queue, trigger calculation for the next result
+                setNextResult();
             }
-            return getResult();
+            return result;
         }
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " DESCENDANT-PAIRS function",
                 getMetadata());
     }
 
+    public void setNextResult() {
+        while (_iterator.hasNext()) {
+            Item item = _iterator.next();
+            List<Item> singleItemList = new ArrayList<>();
+            singleItemList.add(item);
+
+            getDescendantPairs(singleItemList);
+            if (!(_nextResults.isEmpty())) {
+                break;
+            }
+        }
+
+        if (_nextResults.isEmpty()) {
+            this._hasNext = false;
+            _iterator.close();
+        } else {
+            this._hasNext = true;
+        }
+    }
+
     public void getDescendantPairs(List<Item> items) {
         for (Item item:items) {
-            if (item.isArray()) {
-                try {
+            try {
+                if (item.isArray()) {
                     getDescendantPairs(item.getItems());
-                } catch (OperationNotSupportedException e) {
-                    e.printStackTrace();
-                }
-            }
-            else if (item.isObject()) {
-                try {
+                } else if (item.isObject()) {
                     List<String> keys = item.getKeys();
-                    for (String key:keys) {
+                    for (String key : keys) {
                         Item value = item.getItemByKey(key);
 
                         List<String> keyList = Collections.singletonList(key);
                         List<Item> valueList = Collections.singletonList(value);
 
                         ObjectItem result = new ObjectItem(keyList, valueList, ItemMetadata.fromIteratorMetadata(getMetadata()));
-                        results.add(result);
+                        _nextResults.add(result);
                         getDescendantPairs(valueList);
                     }
-                } catch (OperationNotSupportedException e) {
-                    e.printStackTrace();
+                } else {
+                    // do nothing
                 }
-            }
-            else {
-                // do nothing
+            } catch (OperationNotSupportedException e) {
+                e.printStackTrace();
             }
         }
     }

--- a/src/main/resources/test_files/runtime/FunctionArray/FunctionArrayDescendant5.iq
+++ b/src/main/resources/test_files/runtime/FunctionArray/FunctionArrayDescendant5.iq
@@ -1,4 +1,4 @@
-(:JIQS: ShouldRun; Output="( )" :)
+(:JIQS: ShouldRun; Output="" :)
 let $o := ({}) return descendant-arrays($o)
 
 (: to-be-implemented empty object :)

--- a/src/main/resources/test_files/runtime/FunctionObject/FunctionObjectDescendant4.iq
+++ b/src/main/resources/test_files/runtime/FunctionObject/FunctionObjectDescendant4.iq
@@ -1,4 +1,4 @@
-(:JIQS: ShouldRun; Output="( )" :)
+(:JIQS: ShouldRun; Output="" :)
 let $o := ([]) return descendant-objects($o)
 
 (: to-be-implemented empty array :)

--- a/src/main/resources/test_files/runtime/FunctionObject/FunctionObjectDescendant5
+++ b/src/main/resources/test_files/runtime/FunctionObject/FunctionObjectDescendant5
@@ -1,6 +1,0 @@
-(:JIQS: ShouldRun; Output="( )" :)
-let $o := ([]) return descendant-objects($o)
-
-(: to-be-implemented list of atomics :)
-
-

--- a/src/main/resources/test_files/runtime/FunctionObject/FunctionObjectDescendant5.iq
+++ b/src/main/resources/test_files/runtime/FunctionObject/FunctionObjectDescendant5.iq
@@ -1,0 +1,6 @@
+(:JIQS: ShouldRun; Output="" :)
+let $o := ("a", 1, null, 2.0, 3e+2) return descendant-objects($o)
+
+(: list of atomics :)
+
+


### PR DESCRIPTION
Lazy evaluation implemented for descendant functions. Lazy evaluation is implemented in a different manner due to the added complexity caused by recursive structure of the function calls. Each item in the original sequence is recursively investigated to find descendant items of the desired type which are then stored in a queue. Once results returned from the first item is exhausted through next calls, the following item is recursively investigated in the same manner and its results are stored in the queue and so on. 

Empty sequence test cases are activated following the bugfix applied in the previous PR:  https://github.com/Sparksoniq/sparksoniq/pull/57