### PR TITLE
change next() call of EmptySequence Iterator

### DIFF
--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/EmptySequenceIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/EmptySequenceIterator.java
@@ -36,7 +36,6 @@ public class EmptySequenceIterator extends LocalRuntimeIterator {
 
     @Override
     public Item next() {
-        return null;
-        //throw new IteratorFlowException("Invalid next() call on Empty Sequence", getMetadata());
+        throw new IteratorFlowException("Invalid next() call on Empty Sequence", getMetadata());
     }
 }


### PR DESCRIPTION
Since hasNext is always false in emptySequenceIterator iterator by definition. I believe throwing an exception rather than returning null would make more sense in the next() call.