### PR TITLE
Object constructor

### DIFF
--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/strings/ConcatFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/strings/ConcatFunctionIterator.java
@@ -26,13 +26,7 @@ public class ConcatFunctionIterator extends LocalFunctionCallIterator {
                 // if not empty sequence
                 if (item != null) {
                     String stringValue = "";
-                    if (item.isString()) {
-                        try {
-                            stringValue = item.getStringValue();
-                        } catch (OperationNotSupportedException e) {
-                            e.printStackTrace();
-                        }
-                    } else if (item.isAtomic()) {
+                    if (item.isAtomic()) {
                         stringValue = item.serialize();       // for atomic items (not array or object) returns the equivalent string value
                     } else {
                         throw new UnexpectedTypeException("String concat function has arguments that can't be converted to a string " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/StringConcatIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/StringConcatIterator.java
@@ -30,6 +30,8 @@ import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.operational.base.BinaryOperationBaseIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 
+import javax.naming.OperationNotSupportedException;
+
 public class StringConcatIterator extends BinaryOperationBaseIterator {
     public StringConcatIterator(RuntimeIterator left, RuntimeIterator right, IteratorMetadata iteratorMetadata) {
         super(left, right, OperationalExpressionBase.Operator.CONCAT, iteratorMetadata);
@@ -53,15 +55,31 @@ public class StringConcatIterator extends BinaryOperationBaseIterator {
             } else {
                 right = new StringItem("", ItemMetadata.fromIteratorMetadata(getMetadata()));
             }
-            if (!(left instanceof StringItem) || !(right instanceof StringItem))
-                throw new UnexpectedTypeException("String concat expression has non strings args " +
+            if (!(left.isAtomic()) || !(right.isAtomic()))
+                throw new UnexpectedTypeException("String concat expression has arguments that can't be converted to a string " +
                         left.serialize() + ", " + right.serialize(), getMetadata());
-            StringItem leftString = (StringItem) left;
-            StringItem rightString = (StringItem) right;
+            String leftStringValue = "";
+            String rightStringValue = "";
+            try {
+                if (left.isString()) {
+                    leftStringValue = left.getStringValue();
+                } else {
+                    // non-string atomic
+                    leftStringValue = left.serialize();
+                }
+                if (right.isString()) {
+                    rightStringValue = right.getStringValue();
+                } else {
+                    // non-string atomic
+                    rightStringValue = right.serialize();
+                }
+            } catch (OperationNotSupportedException e) {
+                e.printStackTrace();
+            }
             _leftIterator.close();
             _rightIterator.close();
             this._hasNext = false;
-            return new StringItem(leftString.getStringValue().concat(rightString.getStringValue()),
+            return new StringItem(leftStringValue.concat(rightStringValue),
                     ItemMetadata.fromIteratorMetadata(getMetadata()));
         }
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE, getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/StringConcatIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/StringConcatIterator.java
@@ -58,24 +58,10 @@ public class StringConcatIterator extends BinaryOperationBaseIterator {
             if (!(left.isAtomic()) || !(right.isAtomic()))
                 throw new UnexpectedTypeException("String concat expression has arguments that can't be converted to a string " +
                         left.serialize() + ", " + right.serialize(), getMetadata());
-            String leftStringValue = "";
-            String rightStringValue = "";
-            try {
-                if (left.isString()) {
-                    leftStringValue = left.getStringValue();
-                } else {
-                    // non-string atomic
-                    leftStringValue = left.serialize();
-                }
-                if (right.isString()) {
-                    rightStringValue = right.getStringValue();
-                } else {
-                    // non-string atomic
-                    rightStringValue = right.serialize();
-                }
-            } catch (OperationNotSupportedException e) {
-                e.printStackTrace();
-            }
+
+            String leftStringValue = left.serialize();
+            String rightStringValue = right.serialize();
+
             _leftIterator.close();
             _rightIterator.close();
             this._hasNext = false;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ObjectConstructorRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ObjectConstructorRuntimeIterator.java
@@ -43,7 +43,7 @@ public class ObjectConstructorRuntimeIterator extends LocalRuntimeIterator {
     }
 
 
-    public ObjectConstructorRuntimeIterator(List<ObjectConstructorRuntimeIterator> childExpressions,
+    public ObjectConstructorRuntimeIterator(List<RuntimeIterator> childExpressions,
                                             IteratorMetadata iteratorMetadata) {
         super(null, iteratorMetadata);
         childExpressions.forEach(c -> this._children.add(c));
@@ -58,10 +58,12 @@ public class ObjectConstructorRuntimeIterator extends LocalRuntimeIterator {
             if (_isMergedObject) {
                 for (RuntimeIterator iterator : this._children) {
                     iterator.open(_currentDynamicContext);
-                    ObjectItem item = (ObjectItem) iterator.next();
+                    while (iterator.hasNext()) {
+                        ObjectItem item = (ObjectItem) iterator.next();
+                        keys.addAll(item.getKeys());
+                        values.addAll(item.getValues());
+                    }
                     iterator.close();
-                    keys.addAll(item.getKeys());
-                    values.addAll(item.getValues());
                 }
                 this._hasNext = false;
                 return new ObjectItem(keys, values, ItemMetadata.fromIteratorMetadata(getMetadata()));

--- a/src/main/java/sparksoniq/semantics/visitor/RuntimeIteratorVisitor.java
+++ b/src/main/java/sparksoniq/semantics/visitor/RuntimeIteratorVisitor.java
@@ -196,9 +196,9 @@ public class RuntimeIteratorVisitor extends AbstractExpressionOrClauseVisitor<Ru
     @Override
     public RuntimeIterator visitObjectConstructor(ObjectConstructor expression, RuntimeIterator argument) {
         if (expression.isMergedConstructor()) {
-            List<ObjectConstructorRuntimeIterator> childExpressions = new ArrayList<>();
+            List<RuntimeIterator> childExpressions = new ArrayList<>();
             for (Expression child : expression.getChildExpression().getExpressions())
-                childExpressions.add(((ObjectConstructorRuntimeIterator) this.visit(child, argument)));
+                childExpressions.add((this.visit(child, argument)));
             return new ObjectConstructorRuntimeIterator(childExpressions, createIteratorMetadata(expression));
         } else {
             List<RuntimeIterator> keys = new ArrayList<>();

--- a/src/main/resources/test_files/runtime/FunctionString/ConcatFunction2.iq
+++ b/src/main/resources/test_files/runtime/FunctionString/ConcatFunction2.iq
@@ -1,0 +1,5 @@
+(:JIQS: ShouldRun; Output="( 1234true, 12.030.04truenull)" :)
+concat(01, 02, 03, 04, true)
+concat(01, 2.0, 3e+1, 04, true, null)
+
+(: atomic type tests :)

--- a/src/main/resources/test_files/runtime/FunctionString/ConcatFunctionError1.iq
+++ b/src/main/resources/test_files/runtime/FunctionString/ConcatFunctionError1.iq
@@ -1,2 +1,2 @@
-(:JIQS: ShouldCrash; ErrorCode="XPTY0004"; ErrorMetadata="LINE:2:COLUMN:14:" :)
-concat("aaa", 1)
+(:JIQS: ShouldCrash; ErrorCode="XPTY0004"; ErrorMetadata="LINE:2:COLUMN:0:" :)
+concat("aaa", ["a", "b"])

--- a/src/main/resources/test_files/runtime/FunctionString/ConcatFunctionError2.iq
+++ b/src/main/resources/test_files/runtime/FunctionString/ConcatFunctionError2.iq
@@ -1,2 +1,2 @@
-(:JIQS: ShouldCrash; ErrorCode="XPTY0004"; ErrorMetadata="LINE:2:COLUMN:14:" :)
-concat("aaa", 2.0)
+(:JIQS: ShouldCrash; ErrorCode="XPTY0004"; ErrorMetadata="LINE:2:COLUMN:0:" :)
+concat("aaa", [1, 2])

--- a/src/main/resources/test_files/runtime/FunctionString/ConcatFunctionError3.iq
+++ b/src/main/resources/test_files/runtime/FunctionString/ConcatFunctionError3.iq
@@ -1,2 +1,0 @@
-(:JIQS: ShouldCrash; ErrorCode="XPTY0004"; ErrorMetadata="LINE:2:COLUMN:14:" :)
-concat("aaa", 3e+2)

--- a/src/main/resources/test_files/runtime/FunctionString/ConcatFunctionError3.iq
+++ b/src/main/resources/test_files/runtime/FunctionString/ConcatFunctionError3.iq
@@ -1,2 +1,2 @@
 (:JIQS: ShouldCrash; ErrorCode="XPTY0004"; ErrorMetadata="LINE:2:COLUMN:0:" :)
--"aa"
+concat("aaa", {"a": "1"})

--- a/src/main/resources/test_files/runtime/FunctionString/ConcatFunctionError4.iq
+++ b/src/main/resources/test_files/runtime/FunctionString/ConcatFunctionError4.iq
@@ -1,2 +1,0 @@
-(:JIQS: ShouldCrash; ErrorCode="XPTY0004"; ErrorMetadata="LINE:2:COLUMN:14:" :)
-concat("aaa", null)

--- a/src/main/resources/test_files/runtime/FunctionString/ConcatFunctionError5.iq
+++ b/src/main/resources/test_files/runtime/FunctionString/ConcatFunctionError5.iq
@@ -1,2 +1,0 @@
-(:JIQS: ShouldCrash; ErrorCode="XPTY0004"; ErrorMetadata="LINE:2:COLUMN:14:" :)
-concat("aaa", ["a", "b"])

--- a/src/main/resources/test_files/runtime/FunctionString/ConcatFunctionError6.iq
+++ b/src/main/resources/test_files/runtime/FunctionString/ConcatFunctionError6.iq
@@ -1,2 +1,0 @@
-(:JIQS: ShouldCrash; ErrorCode="XPTY0004"; ErrorMetadata="LINE:2:COLUMN:14:" :)
-concat("aaa", [1, 2])

--- a/src/main/resources/test_files/runtime/FunctionString/ConcatFunctionError7.iq
+++ b/src/main/resources/test_files/runtime/FunctionString/ConcatFunctionError7.iq
@@ -1,2 +1,0 @@
-(:JIQS: ShouldCrash; ErrorCode="XPTY0004"; ErrorMetadata="LINE:2:COLUMN:14:" :)
-concat("aaa", {"a": 1})

--- a/src/main/resources/test_files/runtime/Operational/StringConcat1.iq
+++ b/src/main/resources/test_files/runtime/Operational/StringConcat1.iq
@@ -1,4 +1,7 @@
-(:JIQS: ShouldRun; Output="( Captain Kirk, CaptainKirk)" :)
+(:JIQS: ShouldRun; Output="( Captain Kirk, CaptainKirk, aabbccdd)" :)
 "Captain" || " " || "Kirk",
-"Captain" || () || "Kirk"
+"Captain" || () || "Kirk",
+"aa" || "bb" || "cc" || "" || "dd"
+
+(: string values)
 

--- a/src/main/resources/test_files/runtime/Operational/StringConcat2.iq
+++ b/src/main/resources/test_files/runtime/Operational/StringConcat2.iq
@@ -1,2 +1,7 @@
-(:JIQS: ShouldRun; Output="aabbccdd" :)
-"aa" || "bb" || "cc" || "" || "dd"
+(:JIQS: ShouldRun; Output="( 10/6, 1234true, 12.030.04truenull" :)
+10 || "/" || 6,
+01 || 02 || 03 || 04 || true,
+01 || 2.0 || 3e+1 || 04 || true || null
+
+(: atomic values :)
+

--- a/src/main/resources/test_files/runtime/Operational/StringConcatError1.iq
+++ b/src/main/resources/test_files/runtime/Operational/StringConcatError1.iq
@@ -1,2 +1,2 @@
 (:JIQS: ShouldCrash; ErrorCode="XPTY0004"; ErrorMetadata="LINE:2:COLUMN:0:" :)
-"aa" || 2
+"aaa" || ["a", "b"]

--- a/src/main/resources/test_files/runtime/Operational/StringConcatError2.iq
+++ b/src/main/resources/test_files/runtime/Operational/StringConcatError2.iq
@@ -1,2 +1,2 @@
 (:JIQS: ShouldCrash; ErrorCode="XPTY0004"; ErrorMetadata="LINE:2:COLUMN:0:" :)
--"aa"
+"aaa" || [1, 2]

--- a/src/main/resources/test_files/runtime/Operational/StringConcatError3.iq
+++ b/src/main/resources/test_files/runtime/Operational/StringConcatError3.iq
@@ -1,2 +1,2 @@
 (:JIQS: ShouldCrash; ErrorCode="XPTY0004"; ErrorMetadata="LINE:2:COLUMN:0:" :)
--"aa"
+"aaa" || {"a": "1"}

--- a/src/main/resources/test_files/runtime/PrimaryIterators/ObjectConstructor1.iq
+++ b/src/main/resources/test_files/runtime/PrimaryIterators/ObjectConstructor1.iq
@@ -1,0 +1,4 @@
+(:JIQS: ShouldRun; Output="{ "Integer 2" : 4 }" :)
+{ concat("Integer ", 2) : 2 * 2 }
+
+(: dynamic object constructor :)

--- a/src/main/resources/test_files/runtime/PrimaryIterators/ObjectConstructor2.iq
+++ b/src/main/resources/test_files/runtime/PrimaryIterators/ObjectConstructor2.iq
@@ -1,0 +1,4 @@
+(:JIQS: ShouldRun; Output="{ "Square of 1" : 1, "Square of 2" : 4, "Square of 3" : 9, "Square of 4" : 16, "Square of 5" : 25, "Square of 6" : 36, "Square of 7" : 49, "Square of 8" : 64, "Square of 9" : 81, "Square of 10" : 100 }" :)
+{|for $i in 1 to 10 return { concat("Square of ", $i) : $i * $i } |}
+
+(: dynamic object constructor :)


### PR DESCRIPTION
Issue solved: https://github.com/Sparksoniq/sparksoniq/issues/83

String concatenation functions have been improved to work with not only strings but all atomic types.
Test cases changed accordingly

Edit: Also fixed issue: https://github.com/Sparksoniq/sparksoniq/issues/84
Type casting bug fixed with RuntimeIteratorVisitor.
Object constructor improved to work with multiple objects returning from the same iterator.
Test case added.
