### PR TITLE
Remove unnecessary FLWOR clauses from tests

### DIFF
--- a/src/main/resources/test_files/runtime/FunctionArray/FunctionArrayDescendant1.iq
+++ b/src/main/resources/test_files/runtime/FunctionArray/FunctionArrayDescendant1.iq
@@ -1,4 +1,4 @@
 (:JIQS: ShouldRun; Output="( [ 0, x, { "a" : [ 1, { "b" : 2 }, [ 2.5 ] ], "o" : { "c" : 3 } } ], [ 1, { "b" : 2 }, [ 2.5 ] ], [ 2.5 ])" :)
-let $o := ([0, "x", { "a" : [1, {"b" : 2}, [2.5]], "o" : {"c" : 3} }]) return descendant-arrays($o)
+descendant-arrays(([0, "x", { "a" : [1, {"b" : 2}, [2.5]], "o" : {"c" : 3} }]))
 
 (: general functionality :)

--- a/src/main/resources/test_files/runtime/FunctionArray/FunctionArrayDescendant2.iq
+++ b/src/main/resources/test_files/runtime/FunctionArray/FunctionArrayDescendant2.iq
@@ -1,4 +1,4 @@
 (:JIQS: ShouldRun; Output="( [ 0, x, { "a" : [ 1, { "b" : 2 }, [ 2.5 ] ], "o" : { "c" : 3 } } ], [ 1, { "b" : 2 }, [ 2.5 ] ], [ 2.5 ])" :)
-let $o := ({"toplevel" : [0, "x", { "a" : [1, {"b" : 2}, [2.5]], "o" : {"c" : 3} }]}) return descendant-arrays($o)
+descendant-arrays(({"toplevel" : [0, "x", { "a" : [1, {"b" : 2}, [2.5]], "o" : {"c" : 3} }]}))
 
 (: top level object :)

--- a/src/main/resources/test_files/runtime/FunctionArray/FunctionArrayDescendant3.iq
+++ b/src/main/resources/test_files/runtime/FunctionArray/FunctionArrayDescendant3.iq
@@ -1,4 +1,4 @@
 (:JIQS: ShouldRun; Output="( [ 0, x, { "a" : 2.5, "b" : { "c" : 3 } } ] )" :)
-let $o := ([0, "x", { "a" : 2.5, "b" : {"c" : 3} }]) return descendant-arrays($o)
+descendant-arrays(([0, "x", { "a" : 2.5, "b" : {"c" : 3} }]))
 
 (: flat array :)

--- a/src/main/resources/test_files/runtime/FunctionArray/FunctionArrayDescendant4.iq
+++ b/src/main/resources/test_files/runtime/FunctionArray/FunctionArrayDescendant4.iq
@@ -1,4 +1,4 @@
 (:JIQS: ShouldRun; Output="( [ ] )" :)
-let $o := ([]) return descendant-arrays($o)
+descendant-arrays(([]))
 
 (: empty array :)

--- a/src/main/resources/test_files/runtime/FunctionArray/FunctionArrayDescendant5.iq
+++ b/src/main/resources/test_files/runtime/FunctionArray/FunctionArrayDescendant5.iq
@@ -1,4 +1,4 @@
 (:JIQS: ShouldRun; Output="" :)
-let $o := ({}) return descendant-arrays($o)
+descendant-arrays(({}))
 
 (: to-be-implemented empty object :)

--- a/src/main/resources/test_files/runtime/FunctionArray/FunctionArrayFlatten1.iq
+++ b/src/main/resources/test_files/runtime/FunctionArray/FunctionArrayFlatten1.iq
@@ -1,4 +1,4 @@
 (:JIQS: ShouldRun; Output="( 0, x, { "a" : [ 1, { "b" : 2 } ] }, 3, c, d )" :)
-let $o := ([0, "x", { "a" : [1, {"b" : 2}] }, [3, ["c", "d"]]]) return flatten($o)
+flatten(([0, "x", { "a" : [1, {"b" : 2}] }, [3, ["c", "d"]]]))
 
 (: general functionality :)

--- a/src/main/resources/test_files/runtime/FunctionArray/FunctionArrayFlatten2.iq
+++ b/src/main/resources/test_files/runtime/FunctionArray/FunctionArrayFlatten2.iq
@@ -1,5 +1,5 @@
 (:JIQS: ShouldRun; Output="" :)
-let $o := ([]) return flatten($o)
+flatten(([]))
 
 (: empty array :)
 

--- a/src/main/resources/test_files/runtime/FunctionArray/FunctionArrayFlatten3.iq
+++ b/src/main/resources/test_files/runtime/FunctionArray/FunctionArrayFlatten3.iq
@@ -1,4 +1,4 @@
 (:JIQS: ShouldRun; Output="( 0, x, { "a" : 2 } )" :)
-let $o := ([0, "x", { "a" : 2 } ]) return flatten($o)
+flatten(([0, "x", { "a" : 2 } ]))
 
 (: already flat array :)

--- a/src/main/resources/test_files/runtime/FunctionArray/FunctionArrayFlatten4.iq
+++ b/src/main/resources/test_files/runtime/FunctionArray/FunctionArrayFlatten4.iq
@@ -1,4 +1,4 @@
 (:JIQS: ShouldRun; Output="( 0, x, { "a" : 2 } )" :)
-let $o := (0, "x", { "a" : 2 } ) return flatten($o)
+flatten((0, "x", { "a" : 2 } ))
 
 (: sequence with non-array items :)

--- a/src/main/resources/test_files/runtime/FunctionArray/FunctionArrayMembers1.iq
+++ b/src/main/resources/test_files/runtime/FunctionArray/FunctionArrayMembers1.iq
@@ -1,2 +1,2 @@
 (:JIQS: ShouldRun; Output="( mercury, venus, earth, mars, 1, 2, 3)" :)
-let $planets :=  ( "foo", { "foo" : "bar "}, [ "mercury", "venus", "earth", "mars" ], [ 1, 2, 3 ]) return members($planets)
+members(( "foo", { "foo" : "bar "}, [ "mercury", "venus", "earth", "mars" ], [ 1, 2, 3 ]))

--- a/src/main/resources/test_files/runtime/FunctionArray/FunctionArrayMembers2.iq
+++ b/src/main/resources/test_files/runtime/FunctionArray/FunctionArrayMembers2.iq
@@ -1,4 +1,4 @@
 (:JIQS: ShouldRun; Output="" :)
-let $planets :=  ( "foo", { "foo" : "bar "}) return members($planets)
+members(( "foo", { "foo" : "bar "}))
 
 (: empty result :)

--- a/src/main/resources/test_files/runtime/FunctionArray/FunctionArrayMembers3.iq
+++ b/src/main/resources/test_files/runtime/FunctionArray/FunctionArrayMembers3.iq
@@ -1,4 +1,4 @@
 (:JIQS: ShouldRun; Output="" :)
-let $planets :=  ( "foo", { "foo" : "bar ", "array": [1, 2, 3]}) return members($planets)
+members(( "foo", { "foo" : "bar ", "array": [1, 2, 3]}))
 
 (: only top level check :)

--- a/src/main/resources/test_files/runtime/FunctionObject/FunctionObjectDescendant1.iq
+++ b/src/main/resources/test_files/runtime/FunctionObject/FunctionObjectDescendant1.iq
@@ -1,4 +1,4 @@
 (:JIQS: ShouldRun; Output="( { "a" : [ 1, { "b" : 2 } ], "d" : { "c" : 3 } }, { "b" : 2 }, { "c" : 3 } )" :)
-let $o := ({ "a" : [1, {"b" : 2}], "d" : {"c" : 3} }) return descendant-objects($o)
+descendant-objects(({ "a" : [1, {"b" : 2}], "d" : {"c" : 3} }))
 
 (: General functionality :)

--- a/src/main/resources/test_files/runtime/FunctionObject/FunctionObjectDescendant2.iq
+++ b/src/main/resources/test_files/runtime/FunctionObject/FunctionObjectDescendant2.iq
@@ -1,5 +1,5 @@
 (:JIQS: ShouldRun; Output="( { "b" : 2 } )" :)
-let $o := ([1, {"b" : 2}]) return descendant-objects($o)
+descendant-objects(([1, {"b" : 2}]))
 
 (: top level array :)
 

--- a/src/main/resources/test_files/runtime/FunctionObject/FunctionObjectDescendant3.iq
+++ b/src/main/resources/test_files/runtime/FunctionObject/FunctionObjectDescendant3.iq
@@ -1,5 +1,5 @@
 (:JIQS: ShouldRun; Output="( { } )" :)
-let $o := ({}) return descendant-objects($o)
+descendant-objects(({}))
 
 (: empty object :)
 

--- a/src/main/resources/test_files/runtime/FunctionObject/FunctionObjectDescendant4.iq
+++ b/src/main/resources/test_files/runtime/FunctionObject/FunctionObjectDescendant4.iq
@@ -1,5 +1,5 @@
 (:JIQS: ShouldRun; Output="" :)
-let $o := ([]) return descendant-objects($o)
+descendant-objects(([]))
 
 (: to-be-implemented empty array :)
 

--- a/src/main/resources/test_files/runtime/FunctionObject/FunctionObjectDescendant5.iq
+++ b/src/main/resources/test_files/runtime/FunctionObject/FunctionObjectDescendant5.iq
@@ -1,5 +1,5 @@
 (:JIQS: ShouldRun; Output="" :)
-let $o := ("a", 1, null, 2.0, 3e+2) return descendant-objects($o)
+descendant-objects(("a", 1, null, 2.0, 3e+2))
 
 (: list of atomics :)
 


### PR DESCRIPTION
Cleanup PR.

Unnecessary let statements have been cleared from most of the test cases.