### PR TITLE
Cli parameter fix

### DIFF
--- a/src/main/java/sparksoniq/Main.java
+++ b/src/main/java/sparksoniq/Main.java
@@ -36,13 +36,12 @@ import java.util.List;
 public class Main {
     public static void main(String[] args) throws IOException {
         HashMap<String, String> arguments;
-        String masterConfig, outputDataFilePath, queryFilePath = "", logFilePath = "";
+        String outputDataFilePath, queryFilePath = "", logFilePath = "";
         int outputItemLimit = 200;
         try {
             arguments = SparksoniqRuntimeConfiguration.processCommandLineArgs(args);
-            masterConfig = arguments.get("master");
             outputDataFilePath = arguments.get("output-path");
-            initializeApplication(masterConfig);
+            initializeApplication();
             if (arguments.containsKey("query-path"))
                 queryFilePath = arguments.get("query-path");
             if (arguments.containsKey("log-path"))
@@ -53,6 +52,8 @@ public class Main {
         } catch (Exception ex) {
             throw new CliException(ex.getMessage());
         }
+
+        String masterConfig = SparkContextManager.getInstance().getContext().getConf().get("spark.master");
 
         if (masterConfig.contains("local")) {
             System.out.println("Running in local mode");
@@ -80,8 +81,8 @@ public class Main {
         }
     }
 
-    private static void initializeApplication(String masterConfig) {
-        SparkContextManager.getInstance().initializeConfigurationAndContext(masterConfig);
+    private static void initializeApplication() {
+        SparkContextManager.getInstance().initializeConfigurationAndContext();
     }
 
 }

--- a/src/main/java/sparksoniq/ShellStart.java
+++ b/src/main/java/sparksoniq/ShellStart.java
@@ -33,16 +33,15 @@ spark-submit --class sparksoniq.ShellStart     --master yarn-client     --deploy
 --num-executors 40 --conf spark.yarn.maxAppAttempts=1 --conf spark.ui.port=4051
 --conf spark.executor.memory=10g --conf spark.executor.heartbeatInterval=3600s
 --conf spark.network.timeout=3600s
-jsoniq-spark-app-1.0-jar-with-dependencies.jar  --master yarn-client --result-size 1000
+jsoniq-spark-app-1.0-jar-with-dependencies.jar --result-size 1000
 
 
-spark-submit --class sparksoniq.ShellStart  --master local[*]  --deploy-mode client jsoniq-spark-app-1.0-jar-with-dependencies.jar  --master local[*] --result-size 1000
+spark-submit --class sparksoniq.ShellStart  --master local[*]  --deploy-mode client jsoniq-spark-app-1.0-jar-with-dependencies.jar  --result-size 1000
 
  */
 
 public class ShellStart {
     public static void main(String[] args) throws IOException {
-        String masterConfig = "local[*]";
         HashMap<String, String> arguments;
         try {
             arguments = SparksoniqRuntimeConfiguration.processCommandLineArgs(args);
@@ -50,14 +49,8 @@ public class ShellStart {
             System.out.println(ex.getMessage());
             return;
         }
-        if (arguments.containsKey("master"))
-            masterConfig = arguments.get("master");
-        else {
-            arguments.put("master", masterConfig);
-            System.out.println("No master set, defaulting to local!");
-        }
 
-        SparkContextManager.getInstance().initializeConfigurationAndContext(masterConfig);
+        SparkContextManager.getInstance().initializeConfigurationAndContext();
         if (arguments.containsKey("result-size")) {
             int itemLimit = Integer.parseInt(arguments.get("result-size"));
             new JiqsJLineShell(new SparksoniqRuntimeConfiguration(arguments), itemLimit).launch();

--- a/src/main/java/sparksoniq/config/SparksoniqRuntimeConfiguration.java
+++ b/src/main/java/sparksoniq/config/SparksoniqRuntimeConfiguration.java
@@ -49,8 +49,7 @@ public class SparksoniqRuntimeConfiguration {
 
     @Override public String toString(){
         String result = "";
-        result += "Master: " + (_arguments.getOrDefault("master", "local")) + "\n" +
-                "Item Display Limit: " + (_arguments.getOrDefault("result-size", "-")) + "\n" +
+        result += "Item Display Limit: " + (_arguments.getOrDefault("result-size", "-")) + "\n" +
                 "Output Path: " + (_arguments.getOrDefault("output-path", "-")) + "\n" +
                 "Log Path: " + (_arguments.getOrDefault("log-path", "-")) + "\n" +
                 "Query Path : " + (_arguments.getOrDefault("query-path", "-")) + "\n";

--- a/src/main/java/sparksoniq/io/shell/JiqsJLineShell.java
+++ b/src/main/java/sparksoniq/io/shell/JiqsJLineShell.java
@@ -30,6 +30,7 @@ import org.jline.terminal.TerminalBuilder;
 import sparksoniq.JsoniqQueryExecutor;
 import sparksoniq.Main;
 import sparksoniq.config.SparksoniqRuntimeConfiguration;
+import sparksoniq.spark.SparkContextManager;
 import sparksoniq.utils.FileUtils;
 
 import java.io.IOException;

--- a/src/main/java/sparksoniq/spark/SparkContextManager.java
+++ b/src/main/java/sparksoniq/spark/SparkContextManager.java
@@ -35,7 +35,6 @@ import org.apache.spark.api.java.JavaSparkContext;
 
 public class SparkContextManager {
 
-    public static String DEFAULT_MASTER_CONFIG = "local[*]";
     public static int COLLECT_ITEM_LIMIT = 0;
     private static Level LOG_LEVEL = Level.FATAL;
     private static final String APP_NAME = "jsoniq-on-spark";
@@ -56,8 +55,8 @@ public class SparkContextManager {
     private SparkContextManager() {
     }
 
-    public void initializeConfigurationAndContext(String masterConfig) {
-        configuration = new SparkConf().setAppName(APP_NAME).setMaster(masterConfig);
+    public void initializeConfigurationAndContext() {
+        configuration = new SparkConf().setAppName(APP_NAME);
         initialize();
     }
 
@@ -71,7 +70,7 @@ public class SparkContextManager {
     public JavaSparkContext getContext() {
         if (context == null) {
             if (this.configuration == null)
-                initializeConfigurationAndContext(DEFAULT_MASTER_CONFIG);
+                initializeConfigurationAndContext();
             initialize();
         }
         return context;

--- a/src/main/resources/test_files/runtime/FunctionObject/FunctionObjectDescendant2.iq
+++ b/src/main/resources/test_files/runtime/FunctionObject/FunctionObjectDescendant2.iq
@@ -3,4 +3,3 @@ descendant-objects(([1, {"b" : 2}]))
 
 (: top level array :)
 
-

--- a/src/test/java/iq/RuntimeTests.java
+++ b/src/test/java/iq/RuntimeTests.java
@@ -20,6 +20,7 @@
 package iq;
 
 import iq.base.AnnotationsTestsBase;
+import org.apache.spark.SparkConf;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,6 +29,7 @@ import sparksoniq.jsoniq.compiler.JsoniqExpressionTreeVisitor;
 import sparksoniq.jsoniq.item.Item;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.semantics.DynamicContext;
+import sparksoniq.spark.SparkContextManager;
 import utils.FileManager;
 
 import java.io.File;
@@ -65,7 +67,15 @@ public class RuntimeTests extends AnnotationsTestsBase {
     }
 
     public RuntimeTests(File testFile) {
+
         this._testFile = testFile;
+        SparkConf sparkConfiguration = new SparkConf();
+        sparkConfiguration.setMaster("local[*]");
+//        sparkConfiguration.set("spark.driver.memory", "2g");
+//        sparkConfiguration.set("spark.executor.memory",   "2g");
+        sparkConfiguration.set("spark.speculation", "true");
+        sparkConfiguration.set("spark.speculation.quantile", "0.5");
+        SparkContextManager.getInstance().initializeConfigurationAndContext(sparkConfiguration, true);
     }
 
     protected String runIterators(RuntimeIterator iterator) {

--- a/src/test/java/iq/SparkRuntimeTests.java
+++ b/src/test/java/iq/SparkRuntimeTests.java
@@ -37,14 +37,6 @@ public class SparkRuntimeTests extends RuntimeTests {
 
     public SparkRuntimeTests(File testFile) {
         super(testFile);
-        SparkConf sparkConfiguration = new SparkConf();
-        sparkConfiguration.setMaster("local[*]");
-//        sparkConfiguration.set("spark.driver.memory", "2g");
-//        sparkConfiguration.set("spark.executor.memory",   "2g");
-        sparkConfiguration.set("spark.speculation", "true");
-        sparkConfiguration.set("spark.speculation.quantile", "0.5");
-        SparkContextManager.getInstance().initializeConfigurationAndContext(sparkConfiguration, true);
-
     }
 
     @Parameterized.Parameters(name = "{index}:{0}")


### PR DESCRIPTION
In spark master parameters taken within the application override the CLI parameters. To simplify the program startup, master configs within the application have been removed. 

For the shell application, all masterconfigs are removed.

For the batch application (Main.java) with input/output files, most of the masterconfigs have been removed. A check using sparkcontext has been added to detect local/remote execution and proceed accordingly.

Local spark configurations in the SparkRuntimeTests.java file have been moved to RuntimeTests.java to support certain test cases needing Spark execution (Alternatively they can be moved to SparkTests, however this would break the organization where similar tests are co-located in the project)