### PR TITLE
Implement unquoted object keys

### DIFF
--- a/src/main/java/sparksoniq/jsoniq/compiler/JsoniqExpressionTreeVisitor.java
+++ b/src/main/java/sparksoniq/jsoniq/compiler/JsoniqExpressionTreeVisitor.java
@@ -680,8 +680,12 @@ public class JsoniqExpressionTreeVisitor extends sparksoniq.jsoniq.compiler.pars
         Expression rhs,lhs;
         this.visitExprSingle(ctx.rhs);
         rhs = this.currentExpression;
-        this.visitExprSingle(ctx.lhs);
-        lhs = this.currentExpression;
+        if (ctx.lhs != null) {
+            this.visitExprSingle(ctx.lhs);
+            lhs = this.currentExpression;
+        } else {
+            lhs = new StringLiteral(ctx.name.getText(), createMetadataFromContext(ctx));
+        }
         node = new ObjectConstructor.PairConstructor(lhs, rhs, createMetadataFromContext(ctx));
         this.currentPrimaryExpression = node;
         return null;

--- a/src/main/resources/test_files/runtime/ObjectUnquotedKey1.iq
+++ b/src/main/resources/test_files/runtime/ObjectUnquotedKey1.iq
@@ -1,0 +1,4 @@
+(:JIQS: ShouldRun; Output="{ "bar" : 1 }" :)
+{bar : 1}
+
+(: single unquoted key :)

--- a/src/main/resources/test_files/runtime/ObjectUnquotedKey2.iq
+++ b/src/main/resources/test_files/runtime/ObjectUnquotedKey2.iq
@@ -1,0 +1,4 @@
+(:JIQS: ShouldRun; Output="{ "foo" : 1, "bar" : 2, "foofoo" : 3, "barbar" : "conan" }" :)
+{"foo" : 1, bar : 2, foofoo : 3, "barbar" : "conan"}
+
+(: multiple quoted/unquoted keys :)


### PR DESCRIPTION
Issue fixed: https://github.com/Sparksoniq/sparksoniq/issues/62

Support for unquoted object keys implemented. Test cases added