### PR TITLE
Extend HybridIterator in ReturnClause

### DIFF
--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/HybridRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/HybridRuntimeIterator.java
@@ -53,7 +53,7 @@ public abstract class HybridRuntimeIterator extends RuntimeIterator {
     @Override
     public void open(DynamicContext context){
         super.open(context);
-        if(!_isRDD)
+        if(!isRDD())
         {
             openLocal(context);
         }


### PR DESCRIPTION
Return clause now extends the HybridRuntimeIterator.

@ghislainfourny I've updated the HybridRuntimeIterator line 56 to make a call to isRDD rather than a variable lookup. Before the update, the following query was evaluated fully locally, hence producing errors:
min(for $o in json-file("./src/main/resources/queries/conf-ex.json") return $o.date)
This was caused by the execution never reaching the isRDD method.

I have filled implementations of local calls, however if I'm not mistaken, I believe there are no tests we can perform on this yet (before implementing let clause for example). For this reason I'm not sure if my implementations are sound at this point.

Note: This PR is implemented on top of the existing PR #161  to reduce diff size.
