### PR TITLE
Local let clause implementation

### DIFF
--- a/src/main/java/sparksoniq/jsoniq/runtime/tupleiterator/SparkRuntimeTupleIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/tupleiterator/SparkRuntimeTupleIterator.java
@@ -80,6 +80,14 @@ public abstract class SparkRuntimeTupleIterator extends RuntimeTupleIterator {
         return tuple;
     }
 
+    public void setDynamicContext(DynamicContext context){
+        this._currentDynamicContext = context;
+        if(_child != null)
+        {
+            ((SparkRuntimeTupleIterator)_child).setDynamicContext(context);
+        }
+    }
+
     protected JiqsItemParser parser;
     protected JavaRDD<FlworTuple> _rdd;
     protected List<FlworTuple> result = null;

--- a/src/main/java/sparksoniq/semantics/DynamicContext.java
+++ b/src/main/java/sparksoniq/semantics/DynamicContext.java
@@ -46,16 +46,16 @@ public class DynamicContext implements Serializable, KryoSerializable{
 
     public DynamicContext(FlworTuple tuple) {
         this();
-        setBındingsFromTuple(tuple);
+        setBindingsFromTuple(tuple);
     }
 
     public DynamicContext(DynamicContext parent, FlworTuple tuple){
         this._parent = parent;
         this._variableValues = new HashMap<>();
-        setBındingsFromTuple(tuple);
+        setBindingsFromTuple(tuple);
     }
 
-    public void setBındingsFromTuple(FlworTuple tuple) {
+    public void setBindingsFromTuple(FlworTuple tuple) {
         for(String key : tuple.getKeys())
             if(!key.startsWith("."))
                 this.addVariableValue(key,tuple.getValue(key));

--- a/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
@@ -107,9 +107,9 @@ public class LetClauseSparkIterator extends FlowrClauseSparkIterator {
         // evaluate locally
         if (!isRDD()) {
             if (this._child != null) { //if it's not a start clause
-                _tupleContext = new DynamicContext(_currentDynamicContext);     // assign current context as parent
-                _child.open(_tupleContext);
+                _child.open(_currentDynamicContext);
                 _variableName = _variableReference.getVariableName();
+                _tupleContext = new DynamicContext(_currentDynamicContext);     // assign current context as parent
 
                 setNextLocalTupleResult();
 
@@ -118,9 +118,8 @@ public class LetClauseSparkIterator extends FlowrClauseSparkIterator {
                     throw new SparksoniqRuntimeException("Initial let clauses don't support RDDs");
                     // materialize the initial RDD
                 else {
-                    _tupleContext = new DynamicContext(_currentDynamicContext);
                     List<Item> contents = new ArrayList<>();
-                    _expression.open(_tupleContext);
+                    _expression.open(this._currentDynamicContext);
                     while (_expression.hasNext())
                         contents.add(_expression.next());
                     _expression.close();

--- a/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
@@ -107,9 +107,9 @@ public class LetClauseSparkIterator extends FlowrClauseSparkIterator {
         // evaluate locally
         if (!isRDD()) {
             if (this._child != null) { //if it's not a start clause
-                _child.open(_currentDynamicContext);
-                _variableName = _variableReference.getVariableName();
                 _tupleContext = new DynamicContext(_currentDynamicContext);     // assign current context as parent
+                _child.open(_tupleContext);
+                _variableName = _variableReference.getVariableName();
 
                 setNextLocalTupleResult();
 
@@ -118,8 +118,9 @@ public class LetClauseSparkIterator extends FlowrClauseSparkIterator {
                     throw new SparksoniqRuntimeException("Initial let clauses don't support RDDs");
                     // materialize the initial RDD
                 else {
+                    _tupleContext = new DynamicContext(_currentDynamicContext);
                     List<Item> contents = new ArrayList<>();
-                    _expression.open(this._currentDynamicContext);
+                    _expression.open(_tupleContext);
                     while (_expression.hasNext())
                         contents.add(_expression.next());
                     _expression.close();

--- a/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
@@ -103,29 +103,24 @@ public class LetClauseSparkIterator extends FlowrClauseSparkIterator {
     public void open(DynamicContext context) {
         super.open(context);
 
-        // evaluate locally
-        if (!isRDD()) {
-            if (this._child != null) { //if it's not a start clause
-                _child.open(_currentDynamicContext);
-                _tupleContext = new DynamicContext(_currentDynamicContext);     // assign current context as parent
+        // isRDD checks omitted, as open is used for non-RDD(local) operations
 
-                setNextLocalTupleResult();
+        if (this._child != null) { //if it's not a start clause
+            _child.open(_currentDynamicContext);
+            _tupleContext = new DynamicContext(_currentDynamicContext);     // assign current context as parent
 
-            } else {    //if it's a start clause, it returns only one tuple
-                if(_expression.isRDD())
-                    throw new SparksoniqRuntimeException("Initial let clauses don't support RDDs");
-                    // materialize the initial RDD
-                else {
-                    List<Item> contents = new ArrayList<>();
-                    _expression.open(this._currentDynamicContext);
-                    while (_expression.hasNext())
-                        contents.add(_expression.next());
-                    _expression.close();
-                    FlworTuple tuple  = new FlworTuple();
-                    tuple.putValue(_variableName, contents, false);
-                    _nextLocalTupleResult = tuple;
-                }
-            }
+            setNextLocalTupleResult();
+
+        } else {    //if it's a start clause, it returns only one tuple
+            // expression is materialized
+            List<Item> contents = new ArrayList<>();
+            _expression.open(this._currentDynamicContext);
+            while (_expression.hasNext())
+                contents.add(_expression.next());
+            _expression.close();
+            FlworTuple tuple  = new FlworTuple();
+            tuple.putValue(_variableName, contents, false);
+            _nextLocalTupleResult = tuple;
         }
     }
 

--- a/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
@@ -91,9 +91,8 @@ public class LetClauseSparkIterator extends FlowrClauseSparkIterator {
                 _expressionResults.add(_expression.next());
             _expression.close();
 
-            FlworTuple resultTuple = new FlworTuple();
-            resultTuple.putValue(_variableName, _expressionResults, true);
-            _nextLocalTupleResult = resultTuple;
+            inputTuple.putValue(_variableName, _expressionResults, true);
+            _nextLocalTupleResult = inputTuple;
             this._hasNext = true;
         } else {
             _child.close();

--- a/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
@@ -160,17 +160,6 @@ public class LetClauseSparkIterator extends FlowrClauseSparkIterator {
         return rdd;
     }
 
-
-    @Override
-    public boolean hasNext() {
-        return super.hasNext();
-    }
-
-    @Override
-    public void reset(DynamicContext context) {
-        super.reset(context);
-    }
-
     @Override
     public void close() {
         if (_child != null) {

--- a/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
@@ -43,6 +43,7 @@ public class LetClauseSparkIterator extends FlowrClauseSparkIterator {
     private RuntimeIterator _expression;
     private DynamicContext _tupleContext;   // re-use same DynamicContext object for efficiency
     private FlworTuple _nextLocalTupleResult;
+    private List<Item> _expressionResults;  // re-use same list object for efficiency
 
     public LetClauseSparkIterator(RuntimeTupleIterator child, VariableReferenceIterator variableReference, RuntimeIterator expression, IteratorMetadata iteratorMetadata) {
         super(child, null, FLWOR_CLAUSES.LET, iteratorMetadata);
@@ -50,6 +51,7 @@ public class LetClauseSparkIterator extends FlowrClauseSparkIterator {
         this._children.add(expression);
         _variableName = variableReference.getVariableName();
         _expression = expression;
+        _expressionResults = new ArrayList<>();
     }
 
     @Override
@@ -83,14 +85,14 @@ public class LetClauseSparkIterator extends FlowrClauseSparkIterator {
             _tupleContext.removeAllVariables();             // clear the previous variables
             _tupleContext.setBindingsFromTuple(inputTuple);      // assign new variables from new tuple
 
-            List<Item> result = new ArrayList<>();
+            _expressionResults.clear();     // clear the results from previous iteration
             _expression.open(_tupleContext);
             while (_expression.hasNext())
-                result.add(_expression.next());
+                _expressionResults.add(_expression.next());
             _expression.close();
 
             FlworTuple resultTuple = new FlworTuple();
-            resultTuple.putValue(_variableName, result, true);
+            resultTuple.putValue(_variableName, _expressionResults, true);
             _nextLocalTupleResult = resultTuple;
             this._hasNext = true;
         } else {

--- a/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
@@ -22,22 +22,21 @@
 import org.apache.spark.api.java.JavaRDD;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
-import sparksoniq.jsoniq.compiler.translator.expr.flowr.FLWOR_CLAUSES;
 import sparksoniq.jsoniq.item.Item;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.primary.VariableReferenceIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.jsoniq.runtime.tupleiterator.RuntimeTupleIterator;
+import sparksoniq.jsoniq.runtime.tupleiterator.SparkRuntimeTupleIterator;
 import sparksoniq.jsoniq.tuple.FlworTuple;
 import sparksoniq.semantics.DynamicContext;
 import sparksoniq.spark.SparkContextManager;
 import sparksoniq.spark.closures.LetClauseMapClosure;
-import sparksoniq.spark.iterator.flowr.base.FlowrClauseSparkIterator;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class LetClauseSparkIterator extends FlowrClauseSparkIterator {
+public class LetClauseSparkIterator extends SparkRuntimeTupleIterator {
 
     private String _variableName;           // for efficient use in local iteration
     private RuntimeIterator _expression;
@@ -46,9 +45,7 @@ public class LetClauseSparkIterator extends FlowrClauseSparkIterator {
     private List<Item> _expressionResults;  // re-use same list object for efficiency
 
     public LetClauseSparkIterator(RuntimeTupleIterator child, VariableReferenceIterator variableReference, RuntimeIterator expression, IteratorMetadata iteratorMetadata) {
-        super(child, null, FLWOR_CLAUSES.LET, iteratorMetadata);
-        this._children.add(variableReference);
-        this._children.add(expression);
+        super(child, iteratorMetadata);
         _variableName = variableReference.getVariableName();
         _expression = expression;
         _expressionResults = new ArrayList<>();

--- a/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
@@ -20,6 +20,7 @@
  package sparksoniq.spark.iterator.flowr;
 
 import org.apache.spark.api.java.JavaRDD;
+import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
 import sparksoniq.jsoniq.compiler.translator.expr.flowr.FLWOR_CLAUSES;
 import sparksoniq.jsoniq.item.Item;
@@ -28,6 +29,7 @@ import sparksoniq.jsoniq.runtime.iterator.primary.VariableReferenceIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.jsoniq.runtime.tupleiterator.RuntimeTupleIterator;
 import sparksoniq.jsoniq.tuple.FlworTuple;
+import sparksoniq.semantics.DynamicContext;
 import sparksoniq.spark.SparkContextManager;
 import sparksoniq.spark.closures.LetClauseMapClosure;
 import sparksoniq.spark.iterator.flowr.base.FlowrClauseSparkIterator;
@@ -36,25 +38,112 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class LetClauseSparkIterator extends FlowrClauseSparkIterator {
+
+    private VariableReferenceIterator _variableReference;
+    private String _variableName;           // for efficient use in local iteration
+    private RuntimeIterator _expression;
+    private DynamicContext _tupleContext;   // re-use same DynamicContext object for efficiency
+    private FlworTuple _nextLocalTupleResult;
+
     public LetClauseSparkIterator(RuntimeTupleIterator child, VariableReferenceIterator variableReference, RuntimeIterator expression, IteratorMetadata iteratorMetadata) {
         super(child, null, FLWOR_CLAUSES.LET, iteratorMetadata);
         this._children.add(variableReference);
         this._children.add(expression);
+        _variableReference = variableReference;
+        _expression = expression;
     }
-    
+
+    @Override
+    public boolean isRDD() {
+        if (this._child == null) {
+            return false;
+        } else {
+            return _child.isRDD();
+        }
+    }
+
+    @Override
+    public FlworTuple next() {
+        if(_hasNext == true){
+            FlworTuple result = _nextLocalTupleResult;      // save the result to be returned
+            setNextLocalTupleResult();              // calculate and store the next result
+            return result;
+        }
+        throw new IteratorFlowException("Invalid next() call in let flwor clause", getMetadata());
+    }
+
+    private void setNextLocalTupleResult() {
+        // if first let clause, there are no more tuples
+        if (this._child == null) {
+            this._hasNext = false;
+            return;
+        }
+
+        if (_child.hasNext()) {
+            FlworTuple inputTuple = _child.next();
+            _tupleContext.removeAllVariables();             // clear the previous variables
+            _tupleContext.setBindingsFromTuple(inputTuple);      // assign new variables from new tuple
+
+            List<Item> result = new ArrayList<>();
+            _expression.open(_tupleContext);
+            while (_expression.hasNext())
+                result.add(_expression.next());
+            _expression.close();
+
+            FlworTuple resultTuple = new FlworTuple();
+            resultTuple.putValue(_variableName, result, true);
+            _nextLocalTupleResult = resultTuple;
+            this._hasNext = true;
+        } else {
+            _child.close();
+            this._hasNext = false;
+        }
+    }
+
+    @Override
+    public void open(DynamicContext context) {
+        super.open(context);
+
+        // evaluate locally
+        if (!isRDD()) {
+            if (this._child != null) { //if it's not a start clause
+                _child.open(_currentDynamicContext);
+                _variableName = _variableReference.getVariableName();
+                _tupleContext = new DynamicContext(_currentDynamicContext);     // assign current context as parent
+
+                setNextLocalTupleResult();
+
+            } else {    //if it's a start clause, it returns only one tuple
+                if(_expression.isRDD())
+                    throw new SparksoniqRuntimeException("Initial let clauses don't support RDDs");
+                    // materialize the initial RDD
+                else {
+                    List<Item> contents = new ArrayList<>();
+                    _expression.open(this._currentDynamicContext);
+                    while (_expression.hasNext())
+                        contents.add(_expression.next());
+                    _expression.close();
+                    FlworTuple tuple  = new FlworTuple();
+                    tuple.putValue(_variableReference.getVariableName(), contents, false);
+                    _nextLocalTupleResult = tuple;
+                }
+            }
+        }
+    }
+
+
+
     @Override
     public JavaRDD<FlworTuple> getRDD() {
         if (this._rdd == null) {
-            VariableReferenceIterator variableReference = (VariableReferenceIterator)this._children.get(0);
-            RuntimeIterator expression = this._children.get(1);
             //if it's not a start clause
             if (this._child != null) {
                 this._rdd = _child.getRDD();
-                String variableName = variableReference.getVariableName();
-                this._rdd = this._rdd.map(new LetClauseMapClosure(variableName, expression));
+                String variableName = _variableReference.getVariableName();
+                this._rdd = this._rdd.map(new LetClauseMapClosure(variableName, _expression));
             } else {
                 //if it's a start clause
-                _rdd = this.getNewRDDFromExpression(expression);
+                _rdd = this.getNewRDDFromExpression(_expression);
             }
         }
         return _rdd;
@@ -72,10 +161,29 @@ public class LetClauseSparkIterator extends FlowrClauseSparkIterator {
             expression.close();
             List<FlworTuple> tuples = new ArrayList<>();
             FlworTuple tuple  = new FlworTuple();
-            tuple.putValue(((VariableReferenceIterator)this._children.get(0)).getVariableName(), contents, false);
+            tuple.putValue(_variableReference.getVariableName(), contents, false);
             tuples.add(tuple);
             rdd = SparkContextManager.getInstance().getContext().parallelize(tuples);
         }
         return rdd;
     }
+
+
+    @Override
+    public boolean hasNext() {
+        return super.hasNext();
+    }
+
+    @Override
+    public void reset(DynamicContext context) {
+        super.reset(context);
+    }
+
+    @Override
+    public void close() {
+        if (_child != null) {
+            _child.close();
+        }
+    }
+
 }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
@@ -80,9 +80,9 @@ public class ReturnClauseSparkIterator extends HybridRuntimeIterator {
 
     @Override
     protected void openLocal(DynamicContext context) {
-        _child.open(context);
-        _isExpressionOpen = false;
         _tupleContext = new DynamicContext(_currentDynamicContext);     // assign current context as parent
+        _child.open(_tupleContext);
+        _isExpressionOpen = false;
         setNextLocalResult();
     }
 

--- a/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
@@ -101,7 +101,7 @@ public class ReturnClauseSparkIterator extends HybridRuntimeIterator {
         if (_child.hasNext()) {
             FlworTuple tuple = _child.next();
             _tupleContext.removeAllVariables();             // clear the previous variables
-            _tupleContext.setBındingsFromTuple(tuple);      // assign new variables from new tuple
+            _tupleContext.setBindingsFromTuple(tuple);      // assign new variables from new tuple
             _expression.open(_tupleContext);
             _isExpressionOpen = true;
             _nextLocalResult = _expression.next();

--- a/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
@@ -80,9 +80,9 @@ public class ReturnClauseSparkIterator extends HybridRuntimeIterator {
 
     @Override
     protected void openLocal(DynamicContext context) {
-        _tupleContext = new DynamicContext(_currentDynamicContext);     // assign current context as parent
-        _child.open(_tupleContext);
+        _child.open(context);
         _isExpressionOpen = false;
+        _tupleContext = new DynamicContext(_currentDynamicContext);     // assign current context as parent
         setNextLocalResult();
     }
 

--- a/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
@@ -98,20 +98,24 @@ public class ReturnClauseSparkIterator extends HybridRuntimeIterator {
             }
         }
 
-        if (_child.hasNext()) {
+        while (_child.hasNext()) {
             FlworTuple tuple = _child.next();
             _tupleContext.removeAllVariables();             // clear the previous variables
             _tupleContext.setBindingsFromTuple(tuple);      // assign new variables from new tuple
             _expression.open(_tupleContext);
-            _isExpressionOpen = true;
-            _nextLocalResult = _expression.next();
-        } else {
-            _child.close();
-            this._hasNext = false;
-            return;
+            if (_expression.hasNext()) {        // if expression returns a value, set it as next
+                _nextLocalResult = _expression.next();
+                this._hasNext = true;
+                _isExpressionOpen = true;
+                return;
+            } else {    // if not, keep iterating
+                _expression.close();
+            }
         }
-        this._hasNext = true;
 
+        // execution reaches here when there are no more results
+        _child.close();
+        this._hasNext = false;
     }
 
     @Override

--- a/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
@@ -26,10 +26,10 @@ import sparksoniq.jsoniq.runtime.iterator.HybridRuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.jsoniq.runtime.tupleiterator.RuntimeTupleIterator;
+import sparksoniq.jsoniq.runtime.tupleiterator.SparkRuntimeTupleIterator;
 import sparksoniq.jsoniq.tuple.FlworTuple;
 import sparksoniq.semantics.DynamicContext;
 import sparksoniq.spark.closures.ReturnFlatMapClosure;
-import sparksoniq.spark.iterator.flowr.base.FlowrClauseSparkIterator;
 
 import java.util.Arrays;
 
@@ -56,7 +56,7 @@ public class ReturnClauseSparkIterator extends HybridRuntimeIterator {
     @Override
     public JavaRDD<Item> getRDD(DynamicContext context) {
         if(itemRDD == null) {
-            ((FlowrClauseSparkIterator)_child).setDynamicContext(context);
+            ((SparkRuntimeTupleIterator)_child).setDynamicContext(context);
             RuntimeIterator expression = this._children.get(0);
             itemRDD = this._child.getRDD().flatMap(new ReturnFlatMapClosure(expression));
         }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/base/FlowrClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/base/FlowrClauseSparkIterator.java
@@ -72,7 +72,6 @@ public abstract class FlowrClauseSparkIterator extends SparkRuntimeTupleIterator
     //protected FlowrClauseSparkIterator _previousClause = null;
     protected JavaRDD<FlworTuple> _rdd;
     protected final JiqsItemParser _parser;
-    protected DynamicContext _currentDynamicContext;
     protected List<RuntimeIterator> _children;
 
 

--- a/src/main/java/sparksoniq/spark/iterator/flowr/base/FlowrClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/base/FlowrClauseSparkIterator.java
@@ -27,7 +27,6 @@ import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.jsoniq.runtime.tupleiterator.RuntimeTupleIterator;
 import sparksoniq.jsoniq.runtime.tupleiterator.SparkRuntimeTupleIterator;
 import sparksoniq.jsoniq.tuple.FlworTuple;
-import sparksoniq.semantics.DynamicContext;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -43,14 +42,6 @@ public abstract class FlowrClauseSparkIterator extends SparkRuntimeTupleIterator
 //    public void setPreviousClause(FlowrClauseSparkIterator previousClause) {
 //        this._previousClause = previousClause;
 //    }
-
-    public void setDynamicContext(DynamicContext context){
-        this._currentDynamicContext = context;
-        if(_child != null)
-        {
-            ((FlowrClauseSparkIterator)_child).setDynamicContext(context);
-        }
-    }
 
     protected FlowrClauseSparkIterator(
             RuntimeTupleIterator child,

--- a/src/main/resources/test_files/runtime-spark/EmptySequence.iq
+++ b/src/main/resources/test_files/runtime-spark/EmptySequence.iq
@@ -1,2 +1,2 @@
-(:JIQS: ShouldRun; Output="( [ ] )" :)
+(:JIQS: ShouldRun; Output="[ ]" :)
 [ parallelize(()) ]

--- a/src/main/resources/test_files/runtime-spark/LocalClauses/LocalLet1.iq
+++ b/src/main/resources/test_files/runtime-spark/LocalClauses/LocalLet1.iq
@@ -1,0 +1,4 @@
+(:JIQS: ShouldRun; Output="(1, (1, 2))" :)
+let $i := () return $i,
+let $i := 1 return $i,
+let $i := (1, 2) return $i

--- a/src/main/resources/test_files/runtime-spark/LocalClauses/LocalLet2.iq
+++ b/src/main/resources/test_files/runtime-spark/LocalClauses/LocalLet2.iq
@@ -1,0 +1,4 @@
+(:JIQS: ShouldRun; Output="1000" :)
+let $i := 1 to 1000 return count($i)
+
+(: local execution - avoids truncation of spark execution :)

--- a/src/main/resources/test_files/runtime-spark/LocalClauses/LocalLet3.iq
+++ b/src/main/resources/test_files/runtime-spark/LocalClauses/LocalLet3.iq
@@ -1,0 +1,5 @@
+(:JIQS: ShouldRun; Output="(2, 3)" :)
+let $i := 1 let $j := $i + 1 return $j,
+let $i := 1 let $j := $i + 1 return $j + $i
+
+(: multiple lets :)

--- a/src/main/resources/test_files/runtime-spark/LocalClauses/LocalLet4.iq
+++ b/src/main/resources/test_files/runtime-spark/LocalClauses/LocalLet4.iq
@@ -1,0 +1,6 @@
+(:JIQS: ShouldRun; Output="(1, 1, 1, 2, 3)" :)
+let $i := let $j := 1 return $j return $i,
+let $i := let $j := let $k := 1 return $k return $j return $i,
+let $i := let $j := let $k := (1,2) let $l := ($k, 3) return $l return $j return $i
+
+(: Test for nestedness :)

--- a/src/main/resources/test_files/runtime-spark/LocalClauses/LocalLet5.iq
+++ b/src/main/resources/test_files/runtime-spark/LocalClauses/LocalLet5.iq
@@ -1,0 +1,4 @@
+(:JIQS: ShouldRun; Output="5" :)
+let $i := json-file("./src/main/resources/queries/conf-ex.json") return count($i)
+
+(: first let clause with an RDD(gets materialized) :)


### PR DESCRIPTION
I have partially implemented the local let clause support. The following query can be evaluated fully locally.
let $o := {"foobar": 2}
return $o

However, I have ran into an issue that's currently blocking me. Running the following query
let $o := {"foobar": 2}
let $a := ("foo" || "bar")
return $o.$a
causes the following: [ERROR] Error [err: XPDY0130 ] Runtime error retrieving variable $o value

I was wondering whether this was caused by an issue in context chaining or not passing the assignment from the "first let"s tuple(s*) into the "second let". 

Additionally, while looking into the issue of possibly faulty context chaining, I found the "chaining first and opening the child later" much more sensible and made such changes in my last commit. I'd appreciate the feedback on both this change and into the blocking issue very much.

Lastly, I have a very basic question to brush up on my understanding as well as leading up to the issue with the materialization of RDD's for the initial let:
*: Does the let clause always create a single tuple(first let) / preserve the number of tuples (subsequent lets) ?
In the light of this, how should we handle the materialization of an RDD for an initial let clause? Should it be handled as a single tuple or should it be somehow divided into tuples?




