### PR TITLE
Reduce memory footprint.:

### DIFF
--- a/src/main/java/sparksoniq/exceptions/DuplicateObjectKeyException.java
+++ b/src/main/java/sparksoniq/exceptions/DuplicateObjectKeyException.java
@@ -26,7 +26,6 @@ import sparksoniq.jsoniq.compiler.translator.metadata.ExpressionMetadata;
 public class DuplicateObjectKeyException extends SparksoniqRuntimeException{
     public DuplicateObjectKeyException(String keyName, ExpressionMetadata metadata) {
         super("Dynamic error; Two pairs in an object have the same key name: " + keyName + ".",
-                ErrorCodes.DuplicatePairNameErrorCode,
-                metadata);
+                ErrorCodes.DuplicatePairNameErrorCode, metadata);
     }
 }

--- a/src/main/java/sparksoniq/exceptions/DuplicateObjectKeyException.java
+++ b/src/main/java/sparksoniq/exceptions/DuplicateObjectKeyException.java
@@ -24,8 +24,9 @@ import sparksoniq.exceptions.codes.ErrorCodes;
 import sparksoniq.jsoniq.compiler.translator.metadata.ExpressionMetadata;
 
 public class DuplicateObjectKeyException extends SparksoniqRuntimeException{
-    public DuplicateObjectKeyException(String keyName) {
+    public DuplicateObjectKeyException(String keyName, ExpressionMetadata metadata) {
         super("Dynamic error; Two pairs in an object have the same key name: " + keyName + ".",
-                ErrorCodes.DuplicatePairNameErrorCode);
+                ErrorCodes.DuplicatePairNameErrorCode,
+                metadata);
     }
 }

--- a/src/main/java/sparksoniq/exceptions/DuplicateObjectKeyException.java
+++ b/src/main/java/sparksoniq/exceptions/DuplicateObjectKeyException.java
@@ -24,8 +24,8 @@ import sparksoniq.exceptions.codes.ErrorCodes;
 import sparksoniq.jsoniq.compiler.translator.metadata.ExpressionMetadata;
 
 public class DuplicateObjectKeyException extends SparksoniqRuntimeException{
-    public DuplicateObjectKeyException(String keyName, ExpressionMetadata metadata) {
+    public DuplicateObjectKeyException(String keyName) {
         super("Dynamic error; Two pairs in an object have the same key name: " + keyName + ".",
-                ErrorCodes.DuplicatePairNameErrorCode, metadata);
+                ErrorCodes.DuplicatePairNameErrorCode);
     }
 }

--- a/src/main/java/sparksoniq/exceptions/IteratorFlowException.java
+++ b/src/main/java/sparksoniq/exceptions/IteratorFlowException.java
@@ -28,7 +28,7 @@ public class IteratorFlowException extends SparksoniqRuntimeException {
         super(message, ErrorCodes.RuntimeExceptionErrorCode, metadata.getExpressionMetadata());
     }
 
-    public IteratorFlowException(String message, ItemMetadata metadata) {
-        super(message, ErrorCodes.RuntimeExceptionErrorCode, metadata.getExpressionMetadata());
+    public IteratorFlowException(String message) {
+        super(message, ErrorCodes.RuntimeExceptionErrorCode);
     }
 }

--- a/src/main/java/sparksoniq/exceptions/SparksoniqRuntimeException.java
+++ b/src/main/java/sparksoniq/exceptions/SparksoniqRuntimeException.java
@@ -34,6 +34,10 @@ public class SparksoniqRuntimeException extends RuntimeException {
         return metadata;
     }
 
+    public void setMetadata(ExpressionMetadata expressionMetadata) {
+        metadata = expressionMetadata;
+    }
+
     public SparksoniqRuntimeException(String message) {
         super("Error [err: " + ErrorCodes.RuntimeExceptionErrorCode + " ] " + message);
         this.errorCode = ErrorCodes.RuntimeExceptionErrorCode;

--- a/src/main/java/sparksoniq/exceptions/SparksoniqRuntimeException.java
+++ b/src/main/java/sparksoniq/exceptions/SparksoniqRuntimeException.java
@@ -34,13 +34,14 @@ public class SparksoniqRuntimeException extends RuntimeException {
         return metadata;
     }
 
-    public void setMetadata(ExpressionMetadata expressionMetadata) {
-        metadata = expressionMetadata;
+    public String getMessage() {
+        return message;
     }
 
     public SparksoniqRuntimeException(String message) {
         super("Error [err: " + ErrorCodes.RuntimeExceptionErrorCode + " ] " + message);
         this.errorCode = ErrorCodes.RuntimeExceptionErrorCode;
+        this.message = message;
     }
 
     public SparksoniqRuntimeException(String message, String errorCode) {
@@ -55,6 +56,7 @@ public class SparksoniqRuntimeException extends RuntimeException {
             this.errorCode = ErrorCodes.RuntimeExceptionErrorCode;
         else
             this.errorCode = errorCode;
+        this.message = message;
     }
 
 
@@ -74,6 +76,7 @@ public class SparksoniqRuntimeException extends RuntimeException {
         else
             this.errorCode = errorCode;
         this.metadata = metadata;
+        this.message = message;
     }
 
     public SparksoniqRuntimeException(String message,  ExpressionMetadata metadata) {
@@ -83,8 +86,10 @@ public class SparksoniqRuntimeException extends RuntimeException {
                 + message);
         this.errorCode = ErrorCodes.RuntimeExceptionErrorCode;;
         this.metadata = metadata;
+        this.message = message;
     }
 
     private final String errorCode;
+    private final String message;
     private ExpressionMetadata metadata;
 }

--- a/src/main/java/sparksoniq/exceptions/SparksoniqRuntimeException.java
+++ b/src/main/java/sparksoniq/exceptions/SparksoniqRuntimeException.java
@@ -34,14 +34,14 @@ public class SparksoniqRuntimeException extends RuntimeException {
         return metadata;
     }
 
-    public String getMessage() {
-        return message;
+    public String getJSONiqErrorMessage() {
+        return errorMessage;
     }
 
     public SparksoniqRuntimeException(String message) {
         super("Error [err: " + ErrorCodes.RuntimeExceptionErrorCode + " ] " + message);
         this.errorCode = ErrorCodes.RuntimeExceptionErrorCode;
-        this.message = message;
+        this.errorMessage = message;
     }
 
     public SparksoniqRuntimeException(String message, String errorCode) {
@@ -56,7 +56,7 @@ public class SparksoniqRuntimeException extends RuntimeException {
             this.errorCode = ErrorCodes.RuntimeExceptionErrorCode;
         else
             this.errorCode = errorCode;
-        this.message = message;
+        this.errorMessage = message;
     }
 
 
@@ -76,7 +76,7 @@ public class SparksoniqRuntimeException extends RuntimeException {
         else
             this.errorCode = errorCode;
         this.metadata = metadata;
-        this.message = message;
+        this.errorMessage = message;
     }
 
     public SparksoniqRuntimeException(String message,  ExpressionMetadata metadata) {
@@ -86,10 +86,10 @@ public class SparksoniqRuntimeException extends RuntimeException {
                 + message);
         this.errorCode = ErrorCodes.RuntimeExceptionErrorCode;;
         this.metadata = metadata;
-        this.message = message;
+        this.errorMessage = message;
     }
 
     private final String errorCode;
-    private final String message;
+    private final String errorMessage;
     private ExpressionMetadata metadata;
 }

--- a/src/main/java/sparksoniq/io/json/JiqsItemParser.java
+++ b/src/main/java/sparksoniq/io/json/JiqsItemParser.java
@@ -36,22 +36,22 @@ public class JiqsItemParser implements Serializable {
     public static Item getItemFromObject(Object object, IteratorMetadata metadata) {
         if (object != null) {
             if (object instanceof String)
-                return new StringItem(object.toString(), ItemMetadata.fromIteratorMetadata(metadata));
+                return new StringItem(object.toString());
             if (object instanceof Integer)
-                return new IntegerItem((int) object, ItemMetadata.fromIteratorMetadata(metadata));
+                return new IntegerItem((int) object);
             if (object instanceof Double)
-                return new DoubleItem((double) object, ItemMetadata.fromIteratorMetadata(metadata));
+                return new DoubleItem((double) object);
             if (object instanceof BigDecimal)
-                return new DecimalItem(new BigDecimal(object.toString()), ItemMetadata.fromIteratorMetadata(metadata));
+                return new DecimalItem(new BigDecimal(object.toString()));
             if (object instanceof Boolean)
-                return new BooleanItem((boolean) object, ItemMetadata.fromIteratorMetadata(metadata));
+                return new BooleanItem((boolean) object);
             if (object instanceof JSONArray) {
                 JSONArray curentArray = (JSONArray) object;
                 List<Item> values = new ArrayList<>();
                 int index = 0;
                 while (index < curentArray.length())
                     values.add(getItemFromObject(curentArray.get(index++), metadata));
-                return new ArrayItem(values, ItemMetadata.fromIteratorMetadata(metadata));
+                return new ArrayItem(values);
             }
             if (object instanceof JSONObject) {
                 JSONObject currentObject = (JSONObject) object;
@@ -65,7 +65,7 @@ public class JiqsItemParser implements Serializable {
             }
 
         }
-        return new NullItem(ItemMetadata.fromIteratorMetadata(metadata));
+        return new NullItem();
     }
 
 }

--- a/src/main/java/sparksoniq/jsoniq/item/ArrayItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/ArrayItem.java
@@ -37,8 +37,8 @@ public class ArrayItem extends JsonItem {
         return _arrayItems;
     }
 
-    public ArrayItem(List<Item> arrayItems, ItemMetadata itemMetadata){
-        super(itemMetadata);
+    public ArrayItem(List<Item> arrayItems){
+        super();
         this._arrayItems = arrayItems;
     }
 

--- a/src/main/java/sparksoniq/jsoniq/item/AtomicItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/AtomicItem.java
@@ -80,8 +80,8 @@ public abstract class AtomicItem extends Item {
         return false;
     }
 
-    protected AtomicItem(ItemMetadata itemMetadata) {
-        super(itemMetadata);
+    protected AtomicItem() {
+        super();
     }
 
 }

--- a/src/main/java/sparksoniq/jsoniq/item/BooleanItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/BooleanItem.java
@@ -35,8 +35,8 @@ public class BooleanItem extends AtomicItem {
         return _value;
     }
 
-    public BooleanItem(boolean value, ItemMetadata itemMetadata){
-        super(itemMetadata);
+    public BooleanItem(boolean value){
+        super();
         this._value = value;
     }
 

--- a/src/main/java/sparksoniq/jsoniq/item/DecimalItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/DecimalItem.java
@@ -36,8 +36,8 @@ public class DecimalItem extends AtomicItem {
         return _value;
     }
 
-    public DecimalItem(BigDecimal decimal, ItemMetadata itemMetadata){
-        super(itemMetadata);
+    public DecimalItem(BigDecimal decimal){
+        super();
         this._value = decimal;
     }
 

--- a/src/main/java/sparksoniq/jsoniq/item/DoubleItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/DoubleItem.java
@@ -35,8 +35,8 @@ public class DoubleItem extends AtomicItem {
         return _value;
     }
 
-    public DoubleItem(double value, ItemMetadata itemMetadata){
-        super(itemMetadata);
+    public DoubleItem(double value){
+        super();
         this._value = value;
     }
 

--- a/src/main/java/sparksoniq/jsoniq/item/IntegerItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/IntegerItem.java
@@ -22,7 +22,7 @@
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
-import sparksoniq.jsoniq.item.metadata.ItemMetadata;
+
 import sparksoniq.semantics.types.ItemType;
 import sparksoniq.semantics.types.ItemTypes;
 
@@ -35,8 +35,8 @@ public class IntegerItem extends AtomicItem {
         return _value;
     }
 
-    public IntegerItem(int value, ItemMetadata itemMetadata){
-        super(itemMetadata);
+    public IntegerItem(int value){
+        super();
         this._value =value;
     }
 

--- a/src/main/java/sparksoniq/jsoniq/item/Item.java
+++ b/src/main/java/sparksoniq/jsoniq/item/Item.java
@@ -93,7 +93,7 @@ public abstract class Item implements SerializableItem {
             }
 
         }
-        throw new IteratorFlowException("Cannot call getNumericValue on non numeric", item.getItemMetadata());
+        throw new IteratorFlowException("Cannot call getNumericValue on non numeric");
     }
 
     //returns an effective boolean value of any item type
@@ -231,9 +231,9 @@ public abstract class Item implements SerializableItem {
         return false;
     }
 
-    public ItemMetadata getItemMetadata() {
+    /*public ItemMetadata getItemMetadata() {
         return itemMetadata;
-    }
+    }*/
 
     protected Item(ItemMetadata itemMetadata) {
         this.itemMetadata = itemMetadata;

--- a/src/main/java/sparksoniq/jsoniq/item/Item.java
+++ b/src/main/java/sparksoniq/jsoniq/item/Item.java
@@ -231,21 +231,13 @@ public abstract class Item implements SerializableItem {
         return false;
     }
 
-    /*public ItemMetadata getItemMetadata() {
-        return itemMetadata;
-    }*/
-
-    protected Item(ItemMetadata itemMetadata) {
-        this.itemMetadata = itemMetadata;
+    protected Item() {
     }
 
     private void readObject(ObjectInputStream aInputStream)
             throws ClassNotFoundException, IOException {
         aInputStream.defaultReadObject();
     }
-
-    private final ItemMetadata itemMetadata;
-
 
     private void writeObject(ObjectOutputStream aOutputStream)
             throws IOException {

--- a/src/main/java/sparksoniq/jsoniq/item/JsonItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/JsonItem.java
@@ -69,7 +69,7 @@ public abstract class JsonItem extends Item {
         return false;
     }
 
-    protected JsonItem(ItemMetadata itemMetadata) {
-        super(itemMetadata);
+    protected JsonItem() {
+        super();
     }
 }

--- a/src/main/java/sparksoniq/jsoniq/item/NullItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/NullItem.java
@@ -29,7 +29,7 @@ import java.math.BigDecimal;
 
 public class NullItem extends AtomicItem {
 
-    public NullItem(ItemMetadata itemMetadata){super(itemMetadata);}
+    public NullItem(){super();}
 
     @Override
     public String getStringValue() throws OperationNotSupportedException {

--- a/src/main/java/sparksoniq/jsoniq/item/ObjectItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/ObjectItem.java
@@ -23,6 +23,7 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import sparksoniq.exceptions.DuplicateObjectKeyException;
+import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.semantics.types.ItemType;
 import sparksoniq.semantics.types.ItemTypes;
@@ -44,7 +45,13 @@ public class ObjectItem extends JsonItem{
 
     public ObjectItem(List<String> keys, List<Item> values, ItemMetadata itemMetadata){
         super(itemMetadata);
-        checkForDuplicateKeys(keys);
+        try {
+            checkForDuplicateKeys(keys);
+        } catch (DuplicateObjectKeyException e)
+        {
+            e.setMetadata(itemMetadata.getExpressionMetadata());
+            throw e;
+        }
         this._keys = keys;
         this._values = values;
     }
@@ -91,7 +98,7 @@ public class ObjectItem extends JsonItem{
         HashMap<String, Integer> frequencies = new HashMap<>();
         for(String key : keys) {
             if(frequencies.containsKey(key))
-                throw new DuplicateObjectKeyException(key, getItemMetadata().getExpressionMetadata());
+                throw new DuplicateObjectKeyException(key);
 
             else
                 frequencies.put(key, 1);

--- a/src/main/java/sparksoniq/jsoniq/item/ObjectItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/ObjectItem.java
@@ -44,11 +44,13 @@ public class ObjectItem extends JsonItem{
     }
 
     public ObjectItem(List<String> keys, List<Item> values, ItemMetadata itemMetadata){
-        super(itemMetadata);
+        super();
         try {
             checkForDuplicateKeys(keys);
         } catch (DuplicateObjectKeyException e)
         {
+            System.out.println("\nThrow!\n"+itemMetadata.getExpressionMetadata().getTokenColumnNumber()+"\n"+itemMetadata.getExpressionMetadata().getTokenLineNumber());
+            
             e.setMetadata(itemMetadata.getExpressionMetadata());
             throw e;
         }
@@ -62,8 +64,8 @@ public class ObjectItem extends JsonItem{
      * @param keyValuePairs LinkedHashMap -- this map implementation preserves order of the keys -- essential for functionality
      * @param itemMetadata
      */
-    public ObjectItem(LinkedHashMap<String, List<Item>> keyValuePairs, ItemMetadata itemMetadata) {
-        super(itemMetadata);
+    public ObjectItem(LinkedHashMap<String, List<Item>> keyValuePairs) {
+        super();
 
         List<String> keyList = new ArrayList<>();
         List<Item> valueList = new ArrayList<>();
@@ -73,8 +75,7 @@ public class ObjectItem extends JsonItem{
             List<Item> values = keyValuePairs.get(key);
             // for each key, convert the lists of values into arrayItems
             if (values.size() > 1) {
-                ArrayItem valuesArray = new ArrayItem(values
-                        , itemMetadata);
+                ArrayItem valuesArray = new ArrayItem(values);
                 valueList.add(valuesArray);
             }
             else if (values.size() == 1) {

--- a/src/main/java/sparksoniq/jsoniq/item/ObjectItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/ObjectItem.java
@@ -45,15 +45,7 @@ public class ObjectItem extends JsonItem{
 
     public ObjectItem(List<String> keys, List<Item> values, ItemMetadata itemMetadata){
         super();
-        try {
-            checkForDuplicateKeys(keys);
-        } catch (DuplicateObjectKeyException e)
-        {
-            System.out.println("\nThrow!\n"+itemMetadata.getExpressionMetadata().getTokenColumnNumber()+"\n"+itemMetadata.getExpressionMetadata().getTokenLineNumber());
-            
-            e.setMetadata(itemMetadata.getExpressionMetadata());
-            throw e;
-        }
+        checkForDuplicateKeys(keys, itemMetadata);
         this._keys = keys;
         this._values = values;
     }
@@ -95,11 +87,11 @@ public class ObjectItem extends JsonItem{
         this._values = valueList;
     }
 
-    private void checkForDuplicateKeys(List<String> keys) {
+    private void checkForDuplicateKeys(List<String> keys, ItemMetadata metadata) {
         HashMap<String, Integer> frequencies = new HashMap<>();
         for(String key : keys) {
             if(frequencies.containsKey(key))
-                throw new DuplicateObjectKeyException(key);
+                throw new DuplicateObjectKeyException(key, metadata.getExpressionMetadata());
 
             else
                 frequencies.put(key, 1);

--- a/src/main/java/sparksoniq/jsoniq/item/StringItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/StringItem.java
@@ -22,7 +22,7 @@
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
-import sparksoniq.jsoniq.item.metadata.ItemMetadata;
+
 import sparksoniq.semantics.types.ItemType;
 import sparksoniq.semantics.types.ItemTypes;
 
@@ -35,8 +35,8 @@ public class StringItem extends AtomicItem{
         return _value;
     }
 
-    public StringItem(String value, ItemMetadata itemMetadata){
-        super(itemMetadata);
+    public StringItem(String value){
+        super();
         this._value = value;
     }
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/NullFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/NullFunctionIterator.java
@@ -17,6 +17,6 @@ public class NullFunctionIterator extends LocalFunctionCallIterator {
 
     @Override
     public Item next() {
-        return new NullItem(ItemMetadata.fromIteratorMetadata(getMetadata()));
+        return new NullItem();
     }
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArraySizeFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArraySizeFunctionIterator.java
@@ -23,7 +23,6 @@ import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.jsoniq.item.ArrayItem;
 import sparksoniq.jsoniq.item.IntegerItem;
 import sparksoniq.jsoniq.item.Item;
-import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.semantics.DynamicContext;
@@ -57,7 +56,7 @@ public class ArraySizeFunctionIterator extends ArrayFunctionIterator {
             this._hasNext = false;
 
             ArrayItem array = getSingleItemOfTypeFromIterator(arrayIterator, ArrayItem.class);
-            return new IntegerItem(array.getSize(), ItemMetadata.fromIteratorMetadata(getMetadata()));
+            return new IntegerItem(array.getSize());
         }
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + "SIZE function",
                 getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/booleans/BooleanFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/booleans/BooleanFunctionIterator.java
@@ -31,9 +31,9 @@ public class BooleanFunctionIterator extends LocalFunctionCallIterator {
                     }
                 }
 
-                result = new BooleanItem(Item.getEffectiveBooleanValue(item), ItemMetadata.fromIteratorMetadata(getMetadata()));
+                result = new BooleanItem(Item.getEffectiveBooleanValue(item));
             } else {
-                result = new BooleanItem(false, ItemMetadata.fromIteratorMetadata(getMetadata()));
+                result = new BooleanItem(false);
             }
             iterator.close();
             return result;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/AbsFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/AbsFunctionIterator.java
@@ -45,7 +45,6 @@ public class AbsFunctionIterator extends LocalFunctionCallIterator {
                 } catch (IteratorFlowException e)
                 {
                     throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
-
                 }
             }
             else {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/AbsFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/AbsFunctionIterator.java
@@ -41,8 +41,7 @@ public class AbsFunctionIterator extends LocalFunctionCallIterator {
             if (Item.isNumeric(value)) {
                 try {
                     Double result = Math.abs(Item.getNumericValue(value, Double.class));
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+                    return new DoubleItem(result);
                 } catch (IteratorFlowException e)
                 {
                     e.setMetadata(getMetadata().getExpressionMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/AbsFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/AbsFunctionIterator.java
@@ -44,7 +44,7 @@ public class AbsFunctionIterator extends LocalFunctionCallIterator {
                     return new DoubleItem(result);
                 } catch (IteratorFlowException e)
                 {
-                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+                    throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
 
                 }
             }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/AbsFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/AbsFunctionIterator.java
@@ -44,8 +44,8 @@ public class AbsFunctionIterator extends LocalFunctionCallIterator {
                     return new DoubleItem(result);
                 } catch (IteratorFlowException e)
                 {
-                    e.setMetadata(getMetadata().getExpressionMetadata());
-                    throw e;
+                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+
                 }
             }
             else {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/AbsFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/AbsFunctionIterator.java
@@ -39,9 +39,15 @@ public class AbsFunctionIterator extends LocalFunctionCallIterator {
             this._hasNext = false;
             Item value = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
             if (Item.isNumeric(value)) {
-                Double result = Math.abs(Item.getNumericValue(value, Double.class));
-                return new DoubleItem(result,
-                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+                try {
+                    Double result = Math.abs(Item.getNumericValue(value, Double.class));
+                    return new DoubleItem(result,
+                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+                } catch (IteratorFlowException e)
+                {
+                    e.setMetadata(getMetadata().getExpressionMetadata());
+                    throw e;
+                }
             }
             else {
                 throw new UnexpectedTypeException("Abs expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/CeilingFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/CeilingFunctionIterator.java
@@ -39,9 +39,16 @@ public class CeilingFunctionIterator extends LocalFunctionCallIterator {
             this._hasNext = false;
             Item value = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
             if (Item.isNumeric(value)) {
-                Double result = Math.ceil(Item.getNumericValue(value, Double.class));
-                return new DoubleItem(result,
-                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+                try {
+                    Double result = Math.ceil(Item.getNumericValue(value, Double.class));
+                    return new DoubleItem(result,
+                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+
+                } catch (IteratorFlowException e)
+                {
+                    e.setMetadata(getMetadata().getExpressionMetadata());
+                    throw e;
+                }
             } else {
                 throw new UnexpectedTypeException("Ceiling expression has non numeric args " +
                         value.serialize(), getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/CeilingFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/CeilingFunctionIterator.java
@@ -41,8 +41,7 @@ public class CeilingFunctionIterator extends LocalFunctionCallIterator {
             if (Item.isNumeric(value)) {
                 try {
                     Double result = Math.ceil(Item.getNumericValue(value, Double.class));
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+                    return new DoubleItem(result);
 
                 } catch (IteratorFlowException e)
                 {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/CeilingFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/CeilingFunctionIterator.java
@@ -45,8 +45,7 @@ public class CeilingFunctionIterator extends LocalFunctionCallIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    e.setMetadata(getMetadata().getExpressionMetadata());
-                    throw e;
+                    throw new IteratorFlowException(e.getMessage(), getMetadata());
                 }
             } else {
                 throw new UnexpectedTypeException("Ceiling expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/CeilingFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/CeilingFunctionIterator.java
@@ -45,7 +45,7 @@ public class CeilingFunctionIterator extends LocalFunctionCallIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+                    throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
                 }
             } else {
                 throw new UnexpectedTypeException("Ceiling expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/FloorFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/FloorFunctionIterator.java
@@ -45,8 +45,8 @@ public class FloorFunctionIterator extends LocalFunctionCallIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    e.setMetadata(getMetadata().getExpressionMetadata());
-                    throw e;
+                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+
                 }
             } else {
                 throw new UnexpectedTypeException("Floor expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/FloorFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/FloorFunctionIterator.java
@@ -46,7 +46,6 @@ public class FloorFunctionIterator extends LocalFunctionCallIterator {
                 } catch (IteratorFlowException e)
                 {
                     throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
-
                 }
             } else {
                 throw new UnexpectedTypeException("Floor expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/FloorFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/FloorFunctionIterator.java
@@ -41,8 +41,7 @@ public class FloorFunctionIterator extends LocalFunctionCallIterator {
             if (Item.isNumeric(value)) {
                 try {
                     Double result = Math.floor(Item.getNumericValue(value, Double.class));
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+                    return new DoubleItem(result);
 
                 } catch (IteratorFlowException e)
                 {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/FloorFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/FloorFunctionIterator.java
@@ -45,7 +45,7 @@ public class FloorFunctionIterator extends LocalFunctionCallIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+                    throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
 
                 }
             } else {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/FloorFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/FloorFunctionIterator.java
@@ -39,9 +39,16 @@ public class FloorFunctionIterator extends LocalFunctionCallIterator {
             this._hasNext = false;
             Item value = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
             if (Item.isNumeric(value)) {
-                Double result = Math.floor(Item.getNumericValue(value, Double.class));
-                return new DoubleItem(result,
-                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+                try {
+                    Double result = Math.floor(Item.getNumericValue(value, Double.class));
+                    return new DoubleItem(result,
+                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+
+                } catch (IteratorFlowException e)
+                {
+                    e.setMetadata(getMetadata().getExpressionMetadata());
+                    throw e;
+                }
             } else {
                 throw new UnexpectedTypeException("Floor expression has non numeric args " +
                         value.serialize(), getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/PiFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/PiFunctionIterator.java
@@ -19,8 +19,7 @@ public class PiFunctionIterator extends LocalFunctionCallIterator {
     public Item next() {
         if (this._hasNext) {
             this._hasNext = false;
-            return new DoubleItem(Math.PI,
-                    ItemMetadata.fromIteratorMetadata(getMetadata()));
+            return new DoubleItem(Math.PI);
         } else
             throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " pi function", getMetadata());
     }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundFunctionIterator.java
@@ -56,16 +56,23 @@ public class RoundFunctionIterator extends LocalFunctionCallIterator {
                 precision = new IntegerItem(0, ItemMetadata.fromIteratorMetadata(this.getMetadata()));
             }
             if (Item.isNumeric(value) && Item.isNumeric(precision)) {
+                try {
 
-                Double val = Item.getNumericValue(value, Double.class);
-                Integer prec = Item.getNumericValue(precision, Integer.class);
+                    Double val = Item.getNumericValue(value, Double.class);
+                    Integer prec = Item.getNumericValue(precision, Integer.class);
+    
+                    BigDecimal bd = new BigDecimal(val);
+                    bd = bd.setScale(prec, RoundingMode.HALF_UP);
+                    Double result = bd.doubleValue();
+    
+                    return new DoubleItem(result,
+                            ItemMetadata.fromIteratorMetadata(getMetadata()));
 
-                BigDecimal bd = new BigDecimal(val);
-                bd = bd.setScale(prec, RoundingMode.HALF_UP);
-                Double result = bd.doubleValue();
-
-                return new DoubleItem(result,
-                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+                } catch (IteratorFlowException e)
+                {
+                    e.setMetadata(getMetadata().getExpressionMetadata());
+                    throw e;
+                }
             } else {
                 throw new UnexpectedTypeException("Round expression has non numeric args " +
                         value.serialize() + ", " + precision.serialize(), getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundFunctionIterator.java
@@ -69,8 +69,7 @@ public class RoundFunctionIterator extends LocalFunctionCallIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    e.setMetadata(getMetadata().getExpressionMetadata());
-                    throw e;
+                    throw new IteratorFlowException(e.getMessage(), getMetadata());
                 }
             } else {
                 throw new UnexpectedTypeException("Round expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundFunctionIterator.java
@@ -69,7 +69,7 @@ public class RoundFunctionIterator extends LocalFunctionCallIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+                    throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
                 }
             } else {
                 throw new UnexpectedTypeException("Round expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundFunctionIterator.java
@@ -53,7 +53,7 @@ public class RoundFunctionIterator extends LocalFunctionCallIterator {
             }
             // if second param is not given precision is set as 0 (rounds to a whole number)
             else {
-                precision = new IntegerItem(0, ItemMetadata.fromIteratorMetadata(this.getMetadata()));
+                precision = new IntegerItem(0);
             }
             if (Item.isNumeric(value) && Item.isNumeric(precision)) {
                 try {
@@ -65,8 +65,7 @@ public class RoundFunctionIterator extends LocalFunctionCallIterator {
                     bd = bd.setScale(prec, RoundingMode.HALF_UP);
                     Double result = bd.doubleValue();
     
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+                    return new DoubleItem(result);
 
                 } catch (IteratorFlowException e)
                 {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundHalfToEvenFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundHalfToEvenFunctionIterator.java
@@ -70,7 +70,7 @@ public class RoundHalfToEvenFunctionIterator extends LocalFunctionCallIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+                    throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
 
                 }
             } else {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundHalfToEvenFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundHalfToEvenFunctionIterator.java
@@ -57,16 +57,23 @@ public class RoundHalfToEvenFunctionIterator extends LocalFunctionCallIterator {
             }
             if (Item.isNumeric(value) && Item.isNumeric(precision)) {
 
-                Double val = Item.getNumericValue(value, Double.class);
-                Integer prec = Item.getNumericValue(precision, Integer.class);
+                try {
+                    Double val = Item.getNumericValue(value, Double.class);
+                    Integer prec = Item.getNumericValue(precision, Integer.class);
+    
+                    BigDecimal bd = new BigDecimal(val);
+                    bd = bd.setScale(prec, RoundingMode.HALF_EVEN);
+                    Double result = bd.doubleValue();
+    
+    
+                    return new DoubleItem(result,
+                            ItemMetadata.fromIteratorMetadata(getMetadata()));
 
-                BigDecimal bd = new BigDecimal(val);
-                bd = bd.setScale(prec, RoundingMode.HALF_EVEN);
-                Double result = bd.doubleValue();
-
-
-                return new DoubleItem(result,
-                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+                } catch (IteratorFlowException e)
+                {
+                    e.setMetadata(getMetadata().getExpressionMetadata());
+                    throw e;
+                }
             } else {
                 throw new UnexpectedTypeException("Round-half-to-even expression has non numeric args " +
                         value.serialize() + ", " + precision.serialize(), getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundHalfToEvenFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundHalfToEvenFunctionIterator.java
@@ -53,7 +53,7 @@ public class RoundHalfToEvenFunctionIterator extends LocalFunctionCallIterator {
             }
             // if second param is not given precision is set as 0 (rounds to a whole number)
             else {
-                precision = new IntegerItem(0, ItemMetadata.fromIteratorMetadata(this.getMetadata()));
+                precision = new IntegerItem(0);
             }
             if (Item.isNumeric(value) && Item.isNumeric(precision)) {
 
@@ -66,8 +66,7 @@ public class RoundHalfToEvenFunctionIterator extends LocalFunctionCallIterator {
                     Double result = bd.doubleValue();
     
     
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+                    return new DoubleItem(result);
 
                 } catch (IteratorFlowException e)
                 {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundHalfToEvenFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundHalfToEvenFunctionIterator.java
@@ -70,8 +70,8 @@ public class RoundHalfToEvenFunctionIterator extends LocalFunctionCallIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    e.setMetadata(getMetadata().getExpressionMetadata());
-                    throw e;
+                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+
                 }
             } else {
                 throw new UnexpectedTypeException("Round-half-to-even expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundHalfToEvenFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/RoundHalfToEvenFunctionIterator.java
@@ -71,7 +71,6 @@ public class RoundHalfToEvenFunctionIterator extends LocalFunctionCallIterator {
                 } catch (IteratorFlowException e)
                 {
                     throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
-
                 }
             } else {
                 throw new UnexpectedTypeException("Round-half-to-even expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Exp10FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Exp10FunctionIterator.java
@@ -45,8 +45,8 @@ public class Exp10FunctionIterator extends LocalFunctionCallIterator {
                     return new DoubleItem(result);
                 } catch (IteratorFlowException e)
                 {
-                    e.setMetadata(getMetadata().getExpressionMetadata());
-                    throw e;
+                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+
                 }
             } else {
                 throw new UnexpectedTypeException("Exp10 expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Exp10FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Exp10FunctionIterator.java
@@ -46,7 +46,6 @@ public class Exp10FunctionIterator extends LocalFunctionCallIterator {
                 } catch (IteratorFlowException e)
                 {
                     throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
-
                 }
             } else {
                 throw new UnexpectedTypeException("Exp10 expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Exp10FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Exp10FunctionIterator.java
@@ -42,8 +42,7 @@ public class Exp10FunctionIterator extends LocalFunctionCallIterator {
                 try {
                     Double result = Math.pow(10.0, Item.getNumericValue(exponent, Double.class));
     
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+                    return new DoubleItem(result);
                 } catch (IteratorFlowException e)
                 {
                     e.setMetadata(getMetadata().getExpressionMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Exp10FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Exp10FunctionIterator.java
@@ -45,7 +45,7 @@ public class Exp10FunctionIterator extends LocalFunctionCallIterator {
                     return new DoubleItem(result);
                 } catch (IteratorFlowException e)
                 {
-                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+                    throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
 
                 }
             } else {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Exp10FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Exp10FunctionIterator.java
@@ -39,10 +39,16 @@ public class Exp10FunctionIterator extends LocalFunctionCallIterator {
             this._hasNext = false;
             Item exponent = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
             if (Item.isNumeric(exponent)) {
-                Double result = Math.pow(10.0, Item.getNumericValue(exponent, Double.class));
-
-                return new DoubleItem(result,
-                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+                try {
+                    Double result = Math.pow(10.0, Item.getNumericValue(exponent, Double.class));
+    
+                    return new DoubleItem(result,
+                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+                } catch (IteratorFlowException e)
+                {
+                    e.setMetadata(getMetadata().getExpressionMetadata());
+                    throw e;
+                }
             } else {
                 throw new UnexpectedTypeException("Exp10 expression has non numeric args " +
                         exponent.serialize(), getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/ExpFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/ExpFunctionIterator.java
@@ -41,8 +41,7 @@ public class ExpFunctionIterator extends LocalFunctionCallIterator {
             if (Item.isNumeric(exponent)) {
                 try{
                     Double result = Math.exp(Item.getNumericValue(exponent, Double.class));
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+                    return new DoubleItem(result);
 
                 } catch (IteratorFlowException e)
                 {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/ExpFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/ExpFunctionIterator.java
@@ -39,9 +39,16 @@ public class ExpFunctionIterator extends LocalFunctionCallIterator {
             this._hasNext = false;
             Item exponent = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
             if (Item.isNumeric(exponent)) {
-                Double result = Math.exp(Item.getNumericValue(exponent, Double.class));
-                return new DoubleItem(result,
-                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+                try{
+                    Double result = Math.exp(Item.getNumericValue(exponent, Double.class));
+                    return new DoubleItem(result,
+                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+
+                } catch (IteratorFlowException e)
+                {
+                    e.setMetadata(getMetadata().getExpressionMetadata());
+                    throw e;
+                }
             } else {
                 throw new UnexpectedTypeException("Exp expression has non numeric args " +
                         exponent.serialize(), getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/ExpFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/ExpFunctionIterator.java
@@ -46,7 +46,6 @@ public class ExpFunctionIterator extends LocalFunctionCallIterator {
                 } catch (IteratorFlowException e)
                 {
                     throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
-
                 }
             } else {
                 throw new UnexpectedTypeException("Exp expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/ExpFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/ExpFunctionIterator.java
@@ -45,8 +45,8 @@ public class ExpFunctionIterator extends LocalFunctionCallIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    e.setMetadata(getMetadata().getExpressionMetadata());
-                    throw e;
+                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+
                 }
             } else {
                 throw new UnexpectedTypeException("Exp expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/ExpFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/ExpFunctionIterator.java
@@ -45,7 +45,7 @@ public class ExpFunctionIterator extends LocalFunctionCallIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+                    throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
 
                 }
             } else {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Log10FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Log10FunctionIterator.java
@@ -42,8 +42,7 @@ public class Log10FunctionIterator extends LocalFunctionCallIterator {
                 try {
                     Double result = Math.log10(Item.getNumericValue(value, Double.class));
     
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+                    return new DoubleItem(result);
                 
                 } catch (IteratorFlowException e)
                 {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Log10FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Log10FunctionIterator.java
@@ -46,8 +46,8 @@ public class Log10FunctionIterator extends LocalFunctionCallIterator {
                 
                 } catch (IteratorFlowException e)
                 {
-                    e.setMetadata(getMetadata().getExpressionMetadata());
-                    throw e;
+                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+
                 }
             } else {
                 throw new UnexpectedTypeException("Log10 expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Log10FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Log10FunctionIterator.java
@@ -46,7 +46,7 @@ public class Log10FunctionIterator extends LocalFunctionCallIterator {
                 
                 } catch (IteratorFlowException e)
                 {
-                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+                    throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
 
                 }
             } else {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Log10FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Log10FunctionIterator.java
@@ -39,10 +39,17 @@ public class Log10FunctionIterator extends LocalFunctionCallIterator {
             this._hasNext = false;
             Item value = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
             if (Item.isNumeric(value)) {
-                Double result = Math.log10(Item.getNumericValue(value, Double.class));
-
-                return new DoubleItem(result,
-                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+                try {
+                    Double result = Math.log10(Item.getNumericValue(value, Double.class));
+    
+                    return new DoubleItem(result,
+                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+                
+                } catch (IteratorFlowException e)
+                {
+                    e.setMetadata(getMetadata().getExpressionMetadata());
+                    throw e;
+                }
             } else {
                 throw new UnexpectedTypeException("Log10 expression has non numeric args " +
                         value.serialize(), getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Log10FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/Log10FunctionIterator.java
@@ -47,7 +47,6 @@ public class Log10FunctionIterator extends LocalFunctionCallIterator {
                 } catch (IteratorFlowException e)
                 {
                     throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
-
                 }
             } else {
                 throw new UnexpectedTypeException("Log10 expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/LogFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/LogFunctionIterator.java
@@ -45,7 +45,7 @@ public class LogFunctionIterator extends LocalFunctionCallIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+                    throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
 
                 }
             } else {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/LogFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/LogFunctionIterator.java
@@ -41,8 +41,7 @@ public class LogFunctionIterator extends LocalFunctionCallIterator {
             if (Item.isNumeric(value)) {
                 try {
                     Double result = Math.log(Item.getNumericValue(value, Double.class));
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+                    return new DoubleItem(result);
 
                 } catch (IteratorFlowException e)
                 {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/LogFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/LogFunctionIterator.java
@@ -45,8 +45,8 @@ public class LogFunctionIterator extends LocalFunctionCallIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    e.setMetadata(getMetadata().getExpressionMetadata());
-                    throw e;
+                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+
                 }
             } else {
                 throw new UnexpectedTypeException("Log expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/LogFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/LogFunctionIterator.java
@@ -46,7 +46,6 @@ public class LogFunctionIterator extends LocalFunctionCallIterator {
                 } catch (IteratorFlowException e)
                 {
                     throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
-
                 }
             } else {
                 throw new UnexpectedTypeException("Log expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/LogFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/LogFunctionIterator.java
@@ -39,9 +39,16 @@ public class LogFunctionIterator extends LocalFunctionCallIterator {
             this._hasNext = false;
             Item value = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
             if (Item.isNumeric(value)) {
-                Double result = Math.log(Item.getNumericValue(value, Double.class));
-                return new DoubleItem(result,
-                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+                try {
+                    Double result = Math.log(Item.getNumericValue(value, Double.class));
+                    return new DoubleItem(result,
+                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+
+                } catch (IteratorFlowException e)
+                {
+                    e.setMetadata(getMetadata().getExpressionMetadata());
+                    throw e;
+                }
             } else {
                 throw new UnexpectedTypeException("Log expression has non numeric args " +
                         value.serialize(), getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/PowFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/PowFunctionIterator.java
@@ -46,12 +46,17 @@ public class PowFunctionIterator extends LocalFunctionCallIterator {
                 throw new UnexpectedTypeException("Type error; Exponent parameter can't be empty sequence ", getMetadata());
             }
             if (Item.isNumeric(base) && Item.isNumeric(exponent)) {
-                Double result = Math.pow(Item.getNumericValue(base, Double.class)
-                        , Item.getNumericValue(exponent, Double.class));
-                this._hasNext = false;
-                return new DoubleItem(result,
-                        ItemMetadata.fromIteratorMetadata(getMetadata()));
-            } else {
+                try {
+                    Double result = Math.pow(Item.getNumericValue(base, Double.class)
+                            , Item.getNumericValue(exponent, Double.class));
+                    this._hasNext = false;
+                    return new DoubleItem(result,
+                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+                } catch (IteratorFlowException e)
+                {
+                    e.setMetadata(getMetadata().getExpressionMetadata());
+                    throw e;
+                }            } else {
                 throw new UnexpectedTypeException("Pow expression has non numeric args " +
                         base.serialize() + ", " + exponent.serialize(), getMetadata());
             }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/PowFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/PowFunctionIterator.java
@@ -53,7 +53,7 @@ public class PowFunctionIterator extends LocalFunctionCallIterator {
                     return new DoubleItem(result);
                 } catch (IteratorFlowException e)
                 {
-                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+                    throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
 
                 }
             } else {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/PowFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/PowFunctionIterator.java
@@ -53,9 +53,10 @@ public class PowFunctionIterator extends LocalFunctionCallIterator {
                     return new DoubleItem(result);
                 } catch (IteratorFlowException e)
                 {
-                    e.setMetadata(getMetadata().getExpressionMetadata());
-                    throw e;
-                }            } else {
+                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+
+                }
+            } else {
                 throw new UnexpectedTypeException("Pow expression has non numeric args " +
                         base.serialize() + ", " + exponent.serialize(), getMetadata());
             }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/PowFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/PowFunctionIterator.java
@@ -50,8 +50,7 @@ public class PowFunctionIterator extends LocalFunctionCallIterator {
                     Double result = Math.pow(Item.getNumericValue(base, Double.class)
                             , Item.getNumericValue(exponent, Double.class));
                     this._hasNext = false;
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+                    return new DoubleItem(result);
                 } catch (IteratorFlowException e)
                 {
                     e.setMetadata(getMetadata().getExpressionMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/PowFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/PowFunctionIterator.java
@@ -54,7 +54,6 @@ public class PowFunctionIterator extends LocalFunctionCallIterator {
                 } catch (IteratorFlowException e)
                 {
                     throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
-
                 }
             } else {
                 throw new UnexpectedTypeException("Pow expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/SqrtFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/SqrtFunctionIterator.java
@@ -38,10 +38,17 @@ public class SqrtFunctionIterator extends LocalFunctionCallIterator {
         if (this._hasNext) {
             Item value = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
             if (Item.isNumeric(value)) {
-                Double result = Math.sqrt(Item.getNumericValue(value, Double.class));
-                this._hasNext = false;
-                return new DoubleItem(result,
-                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+                try {
+                    Double result = Math.sqrt(Item.getNumericValue(value, Double.class));
+                    this._hasNext = false;
+                    return new DoubleItem(result,
+                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+
+                } catch (IteratorFlowException e)
+                {
+                    e.setMetadata(getMetadata().getExpressionMetadata());
+                    throw e;
+                }
             } else {
                 throw new UnexpectedTypeException("Sqrt expression has non numeric args " +
                         value.serialize(), getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/SqrtFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/SqrtFunctionIterator.java
@@ -46,7 +46,6 @@ public class SqrtFunctionIterator extends LocalFunctionCallIterator {
                 } catch (IteratorFlowException e)
                 {
                     throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
-
                 }
             } else {
                 throw new UnexpectedTypeException("Sqrt expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/SqrtFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/SqrtFunctionIterator.java
@@ -41,8 +41,7 @@ public class SqrtFunctionIterator extends LocalFunctionCallIterator {
                 try {
                     Double result = Math.sqrt(Item.getNumericValue(value, Double.class));
                     this._hasNext = false;
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+                    return new DoubleItem(result);
 
                 } catch (IteratorFlowException e)
                 {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/SqrtFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/SqrtFunctionIterator.java
@@ -45,8 +45,8 @@ public class SqrtFunctionIterator extends LocalFunctionCallIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    e.setMetadata(getMetadata().getExpressionMetadata());
-                    throw e;
+                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+
                 }
             } else {
                 throw new UnexpectedTypeException("Sqrt expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/SqrtFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/exponential/SqrtFunctionIterator.java
@@ -45,7 +45,7 @@ public class SqrtFunctionIterator extends LocalFunctionCallIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+                    throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
 
                 }
             } else {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ACosFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ACosFunctionIterator.java
@@ -46,7 +46,7 @@ public class ACosFunctionIterator extends LocalFunctionCallIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+                    throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
                 }
             } else {
                 throw new UnexpectedTypeException("ACos expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ACosFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ACosFunctionIterator.java
@@ -39,10 +39,17 @@ public class ACosFunctionIterator extends LocalFunctionCallIterator {
             this._hasNext = false;
             Item radians = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
             if (Item.isNumeric(radians)) {
-                Double result = Math.acos(Item.getNumericValue(radians, Double.class));
+                try {
+                    Double result = Math.acos(Item.getNumericValue(radians, Double.class));
+    
+                    return new DoubleItem(result,
+                            ItemMetadata.fromIteratorMetadata(getMetadata()));
 
-                return new DoubleItem(result,
-                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+                } catch (IteratorFlowException e)
+                {
+                    e.setMetadata(getMetadata().getExpressionMetadata());
+                    throw e;
+                }
             } else {
                 throw new UnexpectedTypeException("ACos expression has non numeric args " +
                         radians.serialize(), getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ACosFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ACosFunctionIterator.java
@@ -46,8 +46,7 @@ public class ACosFunctionIterator extends LocalFunctionCallIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
-                }
+                    throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());                }
             } else {
                 throw new UnexpectedTypeException("ACos expression has non numeric args " +
                         radians.serialize(), getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ACosFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ACosFunctionIterator.java
@@ -46,8 +46,7 @@ public class ACosFunctionIterator extends LocalFunctionCallIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    e.setMetadata(getMetadata().getExpressionMetadata());
-                    throw e;
+                    throw new IteratorFlowException(e.getMessage(), getMetadata());
                 }
             } else {
                 throw new UnexpectedTypeException("ACos expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ACosFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ACosFunctionIterator.java
@@ -42,8 +42,7 @@ public class ACosFunctionIterator extends LocalFunctionCallIterator {
                 try {
                     Double result = Math.acos(Item.getNumericValue(radians, Double.class));
     
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+                    return new DoubleItem(result);
 
                 } catch (IteratorFlowException e)
                 {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ASinFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ASinFunctionIterator.java
@@ -45,7 +45,7 @@ public class ASinFunctionIterator extends LocalFunctionCallIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+                    throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
 
                 }
             } else {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ASinFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ASinFunctionIterator.java
@@ -39,9 +39,16 @@ public class ASinFunctionIterator extends LocalFunctionCallIterator {
             this._hasNext = false;
             Item radians = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
             if (Item.isNumeric(radians)) {
-                Double result = Math.asin(Item.getNumericValue(radians, Double.class));
-                return new DoubleItem(result,
-                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+                try {
+                    Double result = Math.asin(Item.getNumericValue(radians, Double.class));
+                    return new DoubleItem(result,
+                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+
+                } catch (IteratorFlowException e)
+                {
+                    e.setMetadata(getMetadata().getExpressionMetadata());
+                    throw e;
+                }
             } else {
                 throw new UnexpectedTypeException("ASin expression has non numeric args " +
                         radians.serialize(), getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ASinFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ASinFunctionIterator.java
@@ -45,8 +45,8 @@ public class ASinFunctionIterator extends LocalFunctionCallIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    e.setMetadata(getMetadata().getExpressionMetadata());
-                    throw e;
+                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+
                 }
             } else {
                 throw new UnexpectedTypeException("ASin expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ASinFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ASinFunctionIterator.java
@@ -46,7 +46,6 @@ public class ASinFunctionIterator extends LocalFunctionCallIterator {
                 } catch (IteratorFlowException e)
                 {
                     throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
-
                 }
             } else {
                 throw new UnexpectedTypeException("ASin expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ASinFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ASinFunctionIterator.java
@@ -41,8 +41,7 @@ public class ASinFunctionIterator extends LocalFunctionCallIterator {
             if (Item.isNumeric(radians)) {
                 try {
                     Double result = Math.asin(Item.getNumericValue(radians, Double.class));
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+                    return new DoubleItem(result);
 
                 } catch (IteratorFlowException e)
                 {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATan2FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATan2FunctionIterator.java
@@ -38,11 +38,18 @@ public class ATan2FunctionIterator extends LocalFunctionCallIterator {
             }
 
             if (Item.isNumeric(y) && Item.isNumeric(x)) {
-                Double result = Math.atan2(Item.getNumericValue(y, Double.class)
-                        , Item.getNumericValue(x, Double.class));
-                this._hasNext = false;
-                return new DoubleItem(result,
-                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+                try {
+                    Double result = Math.atan2(Item.getNumericValue(y, Double.class)
+                            , Item.getNumericValue(x, Double.class));
+                    this._hasNext = false;
+                    return new DoubleItem(result,
+                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+
+                } catch (IteratorFlowException e)
+                {
+                    e.setMetadata(getMetadata().getExpressionMetadata());
+                    throw e;
+                }
             } else {
                 throw new UnexpectedTypeException("ATan2 expression has non numeric args " +
                         y.serialize() + ", " + x.serialize(), getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATan2FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATan2FunctionIterator.java
@@ -46,7 +46,7 @@ public class ATan2FunctionIterator extends LocalFunctionCallIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+                    throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
 
                 }
             } else {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATan2FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATan2FunctionIterator.java
@@ -46,8 +46,8 @@ public class ATan2FunctionIterator extends LocalFunctionCallIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    e.setMetadata(getMetadata().getExpressionMetadata());
-                    throw e;
+                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+
                 }
             } else {
                 throw new UnexpectedTypeException("ATan2 expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATan2FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATan2FunctionIterator.java
@@ -42,8 +42,7 @@ public class ATan2FunctionIterator extends LocalFunctionCallIterator {
                     Double result = Math.atan2(Item.getNumericValue(y, Double.class)
                             , Item.getNumericValue(x, Double.class));
                     this._hasNext = false;
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+                    return new DoubleItem(result);
 
                 } catch (IteratorFlowException e)
                 {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATan2FunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATan2FunctionIterator.java
@@ -47,7 +47,6 @@ public class ATan2FunctionIterator extends LocalFunctionCallIterator {
                 } catch (IteratorFlowException e)
                 {
                     throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
-
                 }
             } else {
                 throw new UnexpectedTypeException("ATan2 expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATanFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATanFunctionIterator.java
@@ -46,7 +46,6 @@ public class ATanFunctionIterator extends LocalFunctionCallIterator {
                 } catch (IteratorFlowException e)
                 {
                     throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
-
                 }
             } else {
                 throw new UnexpectedTypeException("ATan expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATanFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATanFunctionIterator.java
@@ -39,9 +39,16 @@ public class ATanFunctionIterator extends LocalFunctionCallIterator {
             this._hasNext = false;
             Item radians = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
             if (Item.isNumeric(radians)) {
-                Double result = Math.atan(Item.getNumericValue(radians, Double.class));
-                return new DoubleItem(result,
-                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+                try {
+                    Double result = Math.atan(Item.getNumericValue(radians, Double.class));
+                    return new DoubleItem(result,
+                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+
+                } catch (IteratorFlowException e)
+                {
+                    e.setMetadata(getMetadata().getExpressionMetadata());
+                    throw e;
+                }
             } else {
                 throw new UnexpectedTypeException("ATan expression has non numeric args " +
                         radians.serialize(), getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATanFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATanFunctionIterator.java
@@ -41,8 +41,7 @@ public class ATanFunctionIterator extends LocalFunctionCallIterator {
             if (Item.isNumeric(radians)) {
                 try {
                     Double result = Math.atan(Item.getNumericValue(radians, Double.class));
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+                    return new DoubleItem(result);
 
                 } catch (IteratorFlowException e)
                 {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATanFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATanFunctionIterator.java
@@ -45,8 +45,8 @@ public class ATanFunctionIterator extends LocalFunctionCallIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    e.setMetadata(getMetadata().getExpressionMetadata());
-                    throw e;
+                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+
                 }
             } else {
                 throw new UnexpectedTypeException("ATan expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATanFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/ATanFunctionIterator.java
@@ -45,7 +45,7 @@ public class ATanFunctionIterator extends LocalFunctionCallIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+                    throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
 
                 }
             } else {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/CosFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/CosFunctionIterator.java
@@ -45,8 +45,8 @@ public class CosFunctionIterator extends LocalFunctionCallIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    e.setMetadata(getMetadata().getExpressionMetadata());
-                    throw e;
+                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+
                 }
             } else {
                 throw new UnexpectedTypeException("Cos expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/CosFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/CosFunctionIterator.java
@@ -45,7 +45,7 @@ public class CosFunctionIterator extends LocalFunctionCallIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+                    throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
 
                 }
             } else {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/CosFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/CosFunctionIterator.java
@@ -39,9 +39,16 @@ public class CosFunctionIterator extends LocalFunctionCallIterator {
             this._hasNext = false;
             Item radians = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
             if (Item.isNumeric(radians)) {
-                Double result = Math.cos(Item.getNumericValue(radians, Double.class));
-                return new DoubleItem(result,
-                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+                try {
+                    Double result = Math.cos(Item.getNumericValue(radians, Double.class));
+                    return new DoubleItem(result,
+                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+
+                } catch (IteratorFlowException e)
+                {
+                    e.setMetadata(getMetadata().getExpressionMetadata());
+                    throw e;
+                }
             } else {
                 throw new UnexpectedTypeException("Cos expression has non numeric args " +
                         radians.serialize(), getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/CosFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/CosFunctionIterator.java
@@ -41,8 +41,7 @@ public class CosFunctionIterator extends LocalFunctionCallIterator {
             if (Item.isNumeric(radians)) {
                 try {
                     Double result = Math.cos(Item.getNumericValue(radians, Double.class));
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+                    return new DoubleItem(result);
 
                 } catch (IteratorFlowException e)
                 {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/CosFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/CosFunctionIterator.java
@@ -46,7 +46,6 @@ public class CosFunctionIterator extends LocalFunctionCallIterator {
                 } catch (IteratorFlowException e)
                 {
                     throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
-
                 }
             } else {
                 throw new UnexpectedTypeException("Cos expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/SinFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/SinFunctionIterator.java
@@ -41,8 +41,7 @@ public class SinFunctionIterator extends LocalFunctionCallIterator {
             if (Item.isNumeric(radians)) {
                 try {
                     Double result = Math.sin(Item.getNumericValue(radians, Double.class));
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+                    return new DoubleItem(result);
 
                 } catch (IteratorFlowException e)
                 {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/SinFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/SinFunctionIterator.java
@@ -45,7 +45,7 @@ public class SinFunctionIterator extends LocalFunctionCallIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+                    throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
 
                 }
             } else {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/SinFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/SinFunctionIterator.java
@@ -46,7 +46,6 @@ public class SinFunctionIterator extends LocalFunctionCallIterator {
                 } catch (IteratorFlowException e)
                 {
                     throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
-
                 }
             } else {
                 throw new UnexpectedTypeException("Sin expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/SinFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/SinFunctionIterator.java
@@ -45,8 +45,8 @@ public class SinFunctionIterator extends LocalFunctionCallIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    e.setMetadata(getMetadata().getExpressionMetadata());
-                    throw e;
+                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+
                 }
             } else {
                 throw new UnexpectedTypeException("Sin expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/SinFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/SinFunctionIterator.java
@@ -39,9 +39,16 @@ public class SinFunctionIterator extends LocalFunctionCallIterator {
             this._hasNext = false;
             Item radians = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
             if (Item.isNumeric(radians)) {
-                Double result = Math.sin(Item.getNumericValue(radians, Double.class));
-                return new DoubleItem(result,
-                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+                try {
+                    Double result = Math.sin(Item.getNumericValue(radians, Double.class));
+                    return new DoubleItem(result,
+                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+
+                } catch (IteratorFlowException e)
+                {
+                    e.setMetadata(getMetadata().getExpressionMetadata());
+                    throw e;
+                }
             } else {
                 throw new UnexpectedTypeException("Sin expression has non numeric args " +
                         radians.serialize(), getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/TanFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/TanFunctionIterator.java
@@ -41,8 +41,7 @@ public class TanFunctionIterator extends LocalFunctionCallIterator {
             if (Item.isNumeric(radians)) {
                 try {
                     Double result = Math.tan(Item.getNumericValue(radians, Double.class));
-                    return new DoubleItem(result,
-                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+                    return new DoubleItem(result);
 
                 } catch (IteratorFlowException e)
                 {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/TanFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/TanFunctionIterator.java
@@ -46,7 +46,6 @@ public class TanFunctionIterator extends LocalFunctionCallIterator {
                 } catch (IteratorFlowException e)
                 {
                     throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
-
                 }
             } else {
                 throw new UnexpectedTypeException("Tan expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/TanFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/TanFunctionIterator.java
@@ -45,7 +45,7 @@ public class TanFunctionIterator extends LocalFunctionCallIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+                    throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
 
                 }
             } else {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/TanFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/TanFunctionIterator.java
@@ -39,9 +39,16 @@ public class TanFunctionIterator extends LocalFunctionCallIterator {
             this._hasNext = false;
             Item radians = this.getSingleItemOfTypeFromIterator(_iterator, Item.class);
             if (Item.isNumeric(radians)) {
-                Double result = Math.tan(Item.getNumericValue(radians, Double.class));
-                return new DoubleItem(result,
-                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+                try {
+                    Double result = Math.tan(Item.getNumericValue(radians, Double.class));
+                    return new DoubleItem(result,
+                            ItemMetadata.fromIteratorMetadata(getMetadata()));
+
+                } catch (IteratorFlowException e)
+                {
+                    e.setMetadata(getMetadata().getExpressionMetadata());
+                    throw e;
+                }
             } else {
                 throw new UnexpectedTypeException("Tan expression has non numeric args " +
                         radians.serialize(), getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/TanFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/numerics/trigonometric/TanFunctionIterator.java
@@ -45,8 +45,8 @@ public class TanFunctionIterator extends LocalFunctionCallIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    e.setMetadata(getMetadata().getExpressionMetadata());
-                    throw e;
+                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+
                 }
             } else {
                 throw new UnexpectedTypeException("Tan expression has non numeric args " +

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectAccumulateFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectAccumulateFunctionIterator.java
@@ -45,7 +45,7 @@ public class ObjectAccumulateFunctionIterator extends ObjectFunctionIterator {
                 }
             }
 
-            ObjectItem result = new ObjectItem(keyValuePairs, ItemMetadata.fromIteratorMetadata(getMetadata()));
+            ObjectItem result = new ObjectItem(keyValuePairs);
 
             this._hasNext = false;
             return result;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectIntersectFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectIntersectFunctionIterator.java
@@ -62,7 +62,7 @@ public class ObjectIntersectFunctionIterator extends ObjectFunctionIterator {
                 }
             }
 
-            ObjectItem result = new ObjectItem(keyValuePairs, ItemMetadata.fromIteratorMetadata(getMetadata()));
+            ObjectItem result = new ObjectItem(keyValuePairs);
 
             this._hasNext = false;
             return result;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectKeysFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectKeysFunctionIterator.java
@@ -5,7 +5,6 @@ import sparksoniq.jsoniq.item.Item;
 import sparksoniq.jsoniq.item.ItemUtil;
 import sparksoniq.jsoniq.item.ObjectItem;
 import sparksoniq.jsoniq.item.StringItem;
-import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.semantics.DynamicContext;
@@ -59,7 +58,7 @@ public class ObjectKeysFunctionIterator extends ObjectFunctionIterator {
                 ObjectItem objItem = (ObjectItem)item;
                 StringItem result;
                 for (String key : objItem.getKeys()) {
-                    result = new StringItem(key, ItemMetadata.fromIteratorMetadata(getMetadata()));
+                    result = new StringItem(key);
                     // check if key was met earlier
                     if (!ItemUtil.listContainsItem(_prevResults, result))
                     {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/AvgFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/AvgFunctionIterator.java
@@ -44,12 +44,19 @@ public class AvgFunctionIterator extends AggregateFunctionIterator {
                     throw new InvalidArgumentTypeException("Average expression has non numeric args " +
                             r.serialize(), getMetadata());
             });
-            //TODO check numeric types conversions
-            BigDecimal sum = new BigDecimal(0);
-            for (Item r : results)
-                sum = sum.add(Item.getNumericValue(r, BigDecimal.class));
-            return new DecimalItem(sum.divide(new BigDecimal(results.size())),
-                    ItemMetadata.fromIteratorMetadata(getMetadata()));
+            try {
+                //TODO check numeric types conversions
+                BigDecimal sum = new BigDecimal(0);
+                for (Item r : results)
+                    sum = sum.add(Item.getNumericValue(r, BigDecimal.class));
+                return new DecimalItem(sum.divide(new BigDecimal(results.size())),
+                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+
+            } catch (IteratorFlowException e)
+            {
+                e.setMetadata(getMetadata().getExpressionMetadata());
+                throw e;
+            }
         }
         throw new IteratorFlowException(FLOW_EXCEPTION_MESSAGE + "AVG function",
                     getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/AvgFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/AvgFunctionIterator.java
@@ -54,7 +54,6 @@ public class AvgFunctionIterator extends AggregateFunctionIterator {
             } catch (IteratorFlowException e)
             {
                 throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
-
             }
         }
         throw new IteratorFlowException(FLOW_EXCEPTION_MESSAGE + "AVG function",

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/AvgFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/AvgFunctionIterator.java
@@ -53,7 +53,7 @@ public class AvgFunctionIterator extends AggregateFunctionIterator {
 
             } catch (IteratorFlowException e)
             {
-                throw new IteratorFlowException(e.getMessage(), getMetadata());
+                throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
 
             }
         }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/AvgFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/AvgFunctionIterator.java
@@ -49,8 +49,7 @@ public class AvgFunctionIterator extends AggregateFunctionIterator {
                 BigDecimal sum = new BigDecimal(0);
                 for (Item r : results)
                     sum = sum.add(Item.getNumericValue(r, BigDecimal.class));
-                return new DecimalItem(sum.divide(new BigDecimal(results.size())),
-                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+                return new DecimalItem(sum.divide(new BigDecimal(results.size())));
 
             } catch (IteratorFlowException e)
             {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/AvgFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/AvgFunctionIterator.java
@@ -53,8 +53,8 @@ public class AvgFunctionIterator extends AggregateFunctionIterator {
 
             } catch (IteratorFlowException e)
             {
-                e.setMetadata(getMetadata().getExpressionMetadata());
-                throw e;
+                throw new IteratorFlowException(e.getMessage(), getMetadata());
+
             }
         }
         throw new IteratorFlowException(FLOW_EXCEPTION_MESSAGE + "AVG function",

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/CountFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/CountFunctionIterator.java
@@ -23,7 +23,6 @@ import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
 import sparksoniq.jsoniq.item.IntegerItem;
 import sparksoniq.jsoniq.item.Item;
-import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 
@@ -41,8 +40,7 @@ public class CountFunctionIterator extends AggregateFunctionIterator {
             if (!iterator.isRDD()) {
                 List<Item> results = getItemsFromIteratorWithCurrentContext(iterator);
                 this._hasNext = false;
-                return new IntegerItem(results.size(),
-                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+                return new IntegerItem(results.size());
             } else {
                 Long count = iterator.getRDD(_currentDynamicContext).count();
                 this._hasNext = false;
@@ -50,7 +48,7 @@ public class CountFunctionIterator extends AggregateFunctionIterator {
                     // TODO: handle too big x values
                     throw new SparksoniqRuntimeException("The count value is too big to convert to integer type.");
                 } else {
-                    return new IntegerItem(count.intValue(), ItemMetadata.fromIteratorMetadata(getMetadata()));
+                    return new IntegerItem(count.intValue());
                 }
             }
         } else

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/SumFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/SumFunctionIterator.java
@@ -70,7 +70,7 @@ public class SumFunctionIterator extends AggregateFunctionIterator {
                     BigDecimal current = Item.getNumericValue(r, BigDecimal.class);
                     sumResult = sumResult.add(current);
                 }
-                return new DecimalItem(sumResult, ItemMetadata.fromIteratorMetadata(getMetadata()));
+                return new DecimalItem(sumResult);
 
             } catch (IteratorFlowException e)
             {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/SumFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/SumFunctionIterator.java
@@ -75,7 +75,6 @@ public class SumFunctionIterator extends AggregateFunctionIterator {
             } catch (IteratorFlowException e)
             {
                 throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
-
             }
         } else
             throw new IteratorFlowException(FLOW_EXCEPTION_MESSAGE + "SUM function",

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/SumFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/SumFunctionIterator.java
@@ -74,8 +74,8 @@ public class SumFunctionIterator extends AggregateFunctionIterator {
 
             } catch (IteratorFlowException e)
             {
-                e.setMetadata(getMetadata().getExpressionMetadata());
-                throw e;
+                throw new IteratorFlowException(e.getMessage(), getMetadata());
+
             }
         } else
             throw new IteratorFlowException(FLOW_EXCEPTION_MESSAGE + "SUM function",

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/SumFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/SumFunctionIterator.java
@@ -63,15 +63,20 @@ public class SumFunctionIterator extends AggregateFunctionIterator {
                     throw new InvalidArgumentTypeException("Sum expression has non numeric args " +
                             r.serialize(), getMetadata());
             });
+            try {
+                // if input is empty sequence and _zeroItem is not given 0 is returned
+                BigDecimal sumResult = new BigDecimal(0);
+                for (Item r : results) {
+                    BigDecimal current = Item.getNumericValue(r, BigDecimal.class);
+                    sumResult = sumResult.add(current);
+                }
+                return new DecimalItem(sumResult, ItemMetadata.fromIteratorMetadata(getMetadata()));
 
-            // if input is empty sequence and _zeroItem is not given 0 is returned
-            BigDecimal sumResult = new BigDecimal(0);
-            for (Item r : results) {
-                BigDecimal current = Item.getNumericValue(r, BigDecimal.class);
-                sumResult = sumResult.add(current);
+            } catch (IteratorFlowException e)
+            {
+                e.setMetadata(getMetadata().getExpressionMetadata());
+                throw e;
             }
-            return new DecimalItem(sumResult, ItemMetadata.fromIteratorMetadata(getMetadata()));
-
         } else
             throw new IteratorFlowException(FLOW_EXCEPTION_MESSAGE + "SUM function",
                     getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/SumFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/aggregate/SumFunctionIterator.java
@@ -74,7 +74,7 @@ public class SumFunctionIterator extends AggregateFunctionIterator {
 
             } catch (IteratorFlowException e)
             {
-                throw new IteratorFlowException(e.getMessage(), getMetadata());
+                throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
 
             }
         } else

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/general/EmptyFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/general/EmptyFunctionIterator.java
@@ -25,10 +25,10 @@ public class EmptyFunctionIterator extends LocalFunctionCallIterator {
             sequenceIterator.open(_currentDynamicContext);
             Item result;
             if (sequenceIterator.hasNext()) {
-                result = new BooleanItem(false, ItemMetadata.fromIteratorMetadata(getMetadata()));
+                result = new BooleanItem(false);
 
             } else {
-                result = new BooleanItem(true, ItemMetadata.fromIteratorMetadata(getMetadata()));
+                result = new BooleanItem(true);
             }
             sequenceIterator.close();
             return result;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/general/ExistsFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/general/ExistsFunctionIterator.java
@@ -25,10 +25,10 @@ public class ExistsFunctionIterator extends LocalFunctionCallIterator {
             sequenceIterator.open(_currentDynamicContext);
             Item result;
             if (sequenceIterator.hasNext()) {
-                result = new BooleanItem(true, ItemMetadata.fromIteratorMetadata(getMetadata()));
+                result = new BooleanItem(true);
 
             } else {
-                result = new BooleanItem(false, ItemMetadata.fromIteratorMetadata(getMetadata()));
+                result = new BooleanItem(false);
             }
             sequenceIterator.close();
             return result;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/general/SubsequenceFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/general/SubsequenceFunctionIterator.java
@@ -67,7 +67,6 @@ public class SubsequenceFunctionIterator extends LocalFunctionCallIterator {
             } catch (IteratorFlowException e)
             {
                 throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
-
             }
         }
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/general/SubsequenceFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/general/SubsequenceFunctionIterator.java
@@ -66,8 +66,8 @@ public class SubsequenceFunctionIterator extends LocalFunctionCallIterator {
 
             } catch (IteratorFlowException e)
             {
-                e.setMetadata(getMetadata().getExpressionMetadata());
-                throw e;
+                throw new IteratorFlowException(e.getMessage(), getMetadata());
+
             }
         }
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/general/SubsequenceFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/general/SubsequenceFunctionIterator.java
@@ -61,7 +61,14 @@ public class SubsequenceFunctionIterator extends LocalFunctionCallIterator {
             }
             lengthIterator.close();
             // round double to nearest int
-            _length = (int) Math.round((Item.getNumericValue(lengthItem, Double.class)));
+            try {
+                _length = (int) Math.round((Item.getNumericValue(lengthItem, Double.class)));
+
+            } catch (IteratorFlowException e)
+            {
+                e.setMetadata(getMetadata().getExpressionMetadata());
+                throw e;
+            }
         }
 
         // process start position param

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/general/SubsequenceFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/general/SubsequenceFunctionIterator.java
@@ -66,7 +66,7 @@ public class SubsequenceFunctionIterator extends LocalFunctionCallIterator {
 
             } catch (IteratorFlowException e)
             {
-                throw new IteratorFlowException(e.getMessage(), getMetadata());
+                throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
 
             }
         }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/value/DeepEqualFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/value/DeepEqualFunctionIterator.java
@@ -36,7 +36,7 @@ public class DeepEqualFunctionIterator extends LocalFunctionCallIterator {
             List<Item> items2 = getItemsFromIteratorWithCurrentContext(sequenceIterator2);
 
             boolean res = checkDeepEqual(items1, items2);
-            return new BooleanItem(res, ItemMetadata.fromIteratorMetadata(getMetadata()));
+            return new BooleanItem(res);
         } else {
             throw new IteratorFlowException(FLOW_EXCEPTION_MESSAGE + "deep-equal function", getMetadata());
         }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/value/IndexOfFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/value/IndexOfFunctionIterator.java
@@ -5,7 +5,6 @@ import sparksoniq.exceptions.NonAtomicKeyException;
 import sparksoniq.exceptions.UnexpectedTypeException;
 import sparksoniq.jsoniq.item.IntegerItem;
 import sparksoniq.jsoniq.item.Item;
-import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.LocalFunctionCallIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
@@ -70,7 +69,7 @@ public class IndexOfFunctionIterator extends LocalFunctionCallIterator {
                 throw new NonAtomicKeyException("Invalid args. index-of can't be performed with a non-atomic in the input sequence", getMetadata().getExpressionMetadata());
             } else {
                 if (Item.compareItems(item, _search) == 0) {
-                    _nextResult = new IntegerItem(_currentIndex, ItemMetadata.fromIteratorMetadata(getMetadata()));
+                    _nextResult = new IntegerItem(_currentIndex);
                     break;
                 }
             }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/strings/ConcatFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/strings/ConcatFunctionIterator.java
@@ -4,7 +4,6 @@ import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.exceptions.UnexpectedTypeException;
 import sparksoniq.jsoniq.item.Item;
 import sparksoniq.jsoniq.item.StringItem;
-import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.LocalFunctionCallIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
@@ -37,7 +36,7 @@ public class ConcatFunctionIterator extends LocalFunctionCallIterator {
                 }
             }
             this._hasNext = false;
-            return new StringItem(builder.toString(), ItemMetadata.fromIteratorMetadata(getMetadata()));
+            return new StringItem(builder.toString());
         } else
             throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " substring function", getMetadata());
     }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/strings/StringJoinFunction.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/strings/StringJoinFunction.java
@@ -4,7 +4,6 @@ import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.exceptions.UnexpectedTypeException;
 import sparksoniq.jsoniq.item.Item;
 import sparksoniq.jsoniq.item.StringItem;
-import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.LocalFunctionCallIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
@@ -19,7 +18,7 @@ public class StringJoinFunction extends LocalFunctionCallIterator {
     @Override
     public Item next() {
         if (this._hasNext) {
-            StringItem joinString = new StringItem("", new ItemMetadata(getMetadata().getExpressionMetadata()));
+            StringItem joinString = new StringItem("");
             List<Item> strings = getItemsFromIteratorWithCurrentContext(this._children.get(0));
             if (this._children.size() > 1) {
                 RuntimeIterator joinStringIterator = this._children.get(1);
@@ -38,7 +37,7 @@ public class StringJoinFunction extends LocalFunctionCallIterator {
                 stringBuilder = stringBuilder.append(((StringItem) item).getStringValue());
             }
             this._hasNext = false;
-            return new StringItem(stringBuilder.toString(), ItemMetadata.fromIteratorMetadata(getMetadata()));
+            return new StringItem(stringBuilder.toString());
         } else
             throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " string-join function", getMetadata());
     }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/strings/SubstringFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/strings/SubstringFunctionIterator.java
@@ -5,7 +5,6 @@ import sparksoniq.exceptions.UnexpectedTypeException;
 import sparksoniq.jsoniq.item.IntegerItem;
 import sparksoniq.jsoniq.item.Item;
 import sparksoniq.jsoniq.item.StringItem;
-import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.functions.base.LocalFunctionCallIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
@@ -24,7 +23,7 @@ public class SubstringFunctionIterator extends LocalFunctionCallIterator {
             String result;
             StringItem stringItem = this.getSingleItemOfTypeFromIterator(this._children.get(0), StringItem.class);
             if (stringItem == null) {
-                return new StringItem("", ItemMetadata.fromIteratorMetadata(getMetadata()));
+                return new StringItem("");
             }
             IntegerItem indexItem = this.getSingleItemOfTypeFromIterator(this._children.get(1), IntegerItem.class);
             if (indexItem == null) {
@@ -42,7 +41,7 @@ public class SubstringFunctionIterator extends LocalFunctionCallIterator {
                 result = stringItem.getStringValue().substring(index);
             }
 
-            return new StringItem(result, ItemMetadata.fromIteratorMetadata(getMetadata()));
+            return new StringItem(result);
         } else
             throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + " substring function", getMetadata());
     }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/AdditiveOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/AdditiveOperationIterator.java
@@ -59,7 +59,6 @@ public class AdditiveOperationIterator extends BinaryOperationBaseIterator {
                 } catch (IteratorFlowException e)
                 {
                     throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
-
                 }
             } else if(returnType.equals(DoubleItem.class)){
                 try {
@@ -72,7 +71,6 @@ public class AdditiveOperationIterator extends BinaryOperationBaseIterator {
                 } catch (IteratorFlowException e)
                 {
                     throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
-
                 }
             } else if(returnType.equals(DecimalItem.class)){
                 try {
@@ -85,7 +83,6 @@ public class AdditiveOperationIterator extends BinaryOperationBaseIterator {
                 } catch (IteratorFlowException e)
                 {
                     throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
-
                 }
             } else {
                 throw new IteratorFlowException("Additive expression has non numeric args", getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/AdditiveOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/AdditiveOperationIterator.java
@@ -23,7 +23,6 @@ import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.exceptions.UnexpectedTypeException;
 import sparksoniq.jsoniq.compiler.translator.expr.operational.base.OperationalExpressionBase;
 import sparksoniq.jsoniq.item.*;
-import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.operational.base.BinaryOperationBaseIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
@@ -54,10 +53,8 @@ public class AdditiveOperationIterator extends BinaryOperationBaseIterator {
                     int l = Item.<Integer>getNumericValue(_left, Integer.class);
                     int r = Item.<Integer>getNumericValue(_right, Integer.class);
                     return this._operator == OperationalExpressionBase.Operator.PLUS?
-                            new IntegerItem(l + r,
-                                    ItemMetadata.fromIteratorMetadata(getMetadata())) :
-                            new IntegerItem(l - r,
-                                    ItemMetadata.fromIteratorMetadata(getMetadata()));
+                            new IntegerItem(l + r) :
+                            new IntegerItem(l - r);
 
                 } catch (IteratorFlowException e)
                 {
@@ -69,10 +66,8 @@ public class AdditiveOperationIterator extends BinaryOperationBaseIterator {
                     double l = Item.<Double>getNumericValue(_left, Double.class);
                     double r = Item.<Double>getNumericValue(_right, Double.class);
                     return this._operator == OperationalExpressionBase.Operator.PLUS?
-                            new DoubleItem(l + r,
-                                    ItemMetadata.fromIteratorMetadata(getMetadata())) :
-                            new DoubleItem(l - r,
-                                    ItemMetadata.fromIteratorMetadata(getMetadata()));
+                            new DoubleItem(l + r) :
+                            new DoubleItem(l - r);
 
                 } catch (IteratorFlowException e)
                 {
@@ -84,10 +79,8 @@ public class AdditiveOperationIterator extends BinaryOperationBaseIterator {
                     BigDecimal l = Item.<BigDecimal>getNumericValue(_left, BigDecimal.class);
                     BigDecimal r = Item.<BigDecimal>getNumericValue(_right, BigDecimal.class);
                     return this._operator == OperationalExpressionBase.Operator.PLUS?
-                            new DecimalItem(l.add(r),
-                                    ItemMetadata.fromIteratorMetadata(getMetadata())) :
-                            new DecimalItem(l.subtract(r),
-                                    ItemMetadata.fromIteratorMetadata(getMetadata()));
+                            new DecimalItem(l.add(r)) :
+                            new DecimalItem(l.subtract(r));
 
                 } catch (IteratorFlowException e)
                 {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/AdditiveOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/AdditiveOperationIterator.java
@@ -58,7 +58,7 @@ public class AdditiveOperationIterator extends BinaryOperationBaseIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+                    throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
 
                 }
             } else if(returnType.equals(DoubleItem.class)){
@@ -71,7 +71,7 @@ public class AdditiveOperationIterator extends BinaryOperationBaseIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+                    throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
 
                 }
             } else if(returnType.equals(DecimalItem.class)){
@@ -84,7 +84,7 @@ public class AdditiveOperationIterator extends BinaryOperationBaseIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+                    throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
 
                 }
             } else {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/AdditiveOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/AdditiveOperationIterator.java
@@ -50,29 +50,50 @@ public class AdditiveOperationIterator extends BinaryOperationBaseIterator {
 
             Type returnType = Item.getNumericResultType(_left, _right);
             if(returnType.equals(IntegerItem.class)){
-                int l = Item.<Integer>getNumericValue(_left, Integer.class);
-                int r = Item.<Integer>getNumericValue(_right, Integer.class);
-                return this._operator == OperationalExpressionBase.Operator.PLUS?
-                        new IntegerItem(l + r,
-                                ItemMetadata.fromIteratorMetadata(getMetadata())) :
-                        new IntegerItem(l - r,
-                                ItemMetadata.fromIteratorMetadata(getMetadata()));
+                try {
+                    int l = Item.<Integer>getNumericValue(_left, Integer.class);
+                    int r = Item.<Integer>getNumericValue(_right, Integer.class);
+                    return this._operator == OperationalExpressionBase.Operator.PLUS?
+                            new IntegerItem(l + r,
+                                    ItemMetadata.fromIteratorMetadata(getMetadata())) :
+                            new IntegerItem(l - r,
+                                    ItemMetadata.fromIteratorMetadata(getMetadata()));
+
+                } catch (IteratorFlowException e)
+                {
+                    e.setMetadata(getMetadata().getExpressionMetadata());
+                    throw e;
+                }
             } else if(returnType.equals(DoubleItem.class)){
-                double l = Item.<Double>getNumericValue(_left, Double.class);
-                double r = Item.<Double>getNumericValue(_right, Double.class);
-                return this._operator == OperationalExpressionBase.Operator.PLUS?
-                        new DoubleItem(l + r,
-                                ItemMetadata.fromIteratorMetadata(getMetadata())) :
-                        new DoubleItem(l - r,
-                                ItemMetadata.fromIteratorMetadata(getMetadata()));
+                try {
+                    double l = Item.<Double>getNumericValue(_left, Double.class);
+                    double r = Item.<Double>getNumericValue(_right, Double.class);
+                    return this._operator == OperationalExpressionBase.Operator.PLUS?
+                            new DoubleItem(l + r,
+                                    ItemMetadata.fromIteratorMetadata(getMetadata())) :
+                            new DoubleItem(l - r,
+                                    ItemMetadata.fromIteratorMetadata(getMetadata()));
+
+                } catch (IteratorFlowException e)
+                {
+                    e.setMetadata(getMetadata().getExpressionMetadata());
+                    throw e;
+                }
             } else if(returnType.equals(DecimalItem.class)){
-                BigDecimal l = Item.<BigDecimal>getNumericValue(_left, BigDecimal.class);
-                BigDecimal r = Item.<BigDecimal>getNumericValue(_right, BigDecimal.class);
-                return this._operator == OperationalExpressionBase.Operator.PLUS?
-                        new DecimalItem(l.add(r),
-                                ItemMetadata.fromIteratorMetadata(getMetadata())) :
-                        new DecimalItem(l.subtract(r),
-                                ItemMetadata.fromIteratorMetadata(getMetadata()));
+                try {
+                    BigDecimal l = Item.<BigDecimal>getNumericValue(_left, BigDecimal.class);
+                    BigDecimal r = Item.<BigDecimal>getNumericValue(_right, BigDecimal.class);
+                    return this._operator == OperationalExpressionBase.Operator.PLUS?
+                            new DecimalItem(l.add(r),
+                                    ItemMetadata.fromIteratorMetadata(getMetadata())) :
+                            new DecimalItem(l.subtract(r),
+                                    ItemMetadata.fromIteratorMetadata(getMetadata()));
+
+                } catch (IteratorFlowException e)
+                {
+                    e.setMetadata(getMetadata().getExpressionMetadata());
+                    throw e;
+                }
             } else {
                 throw new IteratorFlowException("Additive expression has non numeric args", getMetadata());
             }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/AdditiveOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/AdditiveOperationIterator.java
@@ -58,8 +58,8 @@ public class AdditiveOperationIterator extends BinaryOperationBaseIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    e.setMetadata(getMetadata().getExpressionMetadata());
-                    throw e;
+                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+
                 }
             } else if(returnType.equals(DoubleItem.class)){
                 try {
@@ -71,8 +71,8 @@ public class AdditiveOperationIterator extends BinaryOperationBaseIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    e.setMetadata(getMetadata().getExpressionMetadata());
-                    throw e;
+                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+
                 }
             } else if(returnType.equals(DecimalItem.class)){
                 try {
@@ -84,8 +84,8 @@ public class AdditiveOperationIterator extends BinaryOperationBaseIterator {
 
                 } catch (IteratorFlowException e)
                 {
-                    e.setMetadata(getMetadata().getExpressionMetadata());
-                    throw e;
+                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+
                 }
             } else {
                 throw new IteratorFlowException("Additive expression has non numeric args", getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/AndOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/AndOperationIterator.java
@@ -51,8 +51,7 @@ public class AndOperationIterator extends BinaryOperationBaseIterator {
             _leftIterator.close();
             _rightIterator.close();
             this._hasNext = false;
-            return new BooleanItem(Item.getEffectiveBooleanValue(left) && Item.getEffectiveBooleanValue(right)
-                    , ItemMetadata.fromIteratorMetadata(getMetadata()));
+            return new BooleanItem(Item.getEffectiveBooleanValue(left) && Item.getEffectiveBooleanValue(right));
         }
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE, getMetadata());
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/ComparisonOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/ComparisonOperationIterator.java
@@ -130,7 +130,7 @@ public class ComparisonOperationIterator extends BinaryOperationBaseIterator {
                     return result;
             }
         }
-        return new BooleanItem(false, ItemMetadata.fromIteratorMetadata(getMetadata()));
+        return new BooleanItem(false);
     }
 
     public BooleanItem comparePair(Item left, Item right) {
@@ -172,22 +172,22 @@ public class ComparisonOperationIterator extends BinaryOperationBaseIterator {
         switch (this._operator) {
             case VC_EQ:
             case GC_EQ:
-                return new BooleanItem(comparison == 0, ItemMetadata.fromIteratorMetadata(getMetadata()));
+                return new BooleanItem(comparison == 0);
             case VC_NE:
             case GC_NE:
-                return new BooleanItem(comparison != 0, ItemMetadata.fromIteratorMetadata(getMetadata()));
+                return new BooleanItem(comparison != 0);
             case VC_LT:
             case GC_LT:
-                return new BooleanItem(comparison < 0, ItemMetadata.fromIteratorMetadata(getMetadata()));
+                return new BooleanItem(comparison < 0);
             case VC_LE:
             case GC_LE:
-                return new BooleanItem(comparison < 0 || comparison == 0, ItemMetadata.fromIteratorMetadata(getMetadata()));
+                return new BooleanItem(comparison < 0 || comparison == 0);
             case VC_GT:
             case GC_GT:
-                return new BooleanItem(comparison > 0, ItemMetadata.fromIteratorMetadata(getMetadata()));
+                return new BooleanItem(comparison > 0);
             case VC_GE:
             case GC_GE:
-                return new BooleanItem(comparison > 0 || comparison == 0, ItemMetadata.fromIteratorMetadata(getMetadata()));
+                return new BooleanItem(comparison > 0 || comparison == 0);
             default:
         }
         throw new IteratorFlowException("Unrecognized operator found", getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/InstanceOfIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/InstanceOfIterator.java
@@ -53,17 +53,17 @@ public class InstanceOfIterator extends UnaryOperationIterator {
             //Empty sequence, more items
             if (items.isEmpty() && (_sequenceType.getArity() == SequenceType.Arity.One ||
                     _sequenceType.getArity() == SequenceType.Arity.OneOrMore)) {
-                return new BooleanItem(false, ItemMetadata.fromIteratorMetadata(getMetadata()));
+                return new BooleanItem(false);
             }
             if (items.size() == 1 && _sequenceType.getArity() == SequenceType.Arity.ZeroOrMore) {
-                return new BooleanItem(false, ItemMetadata.fromIteratorMetadata(getMetadata()));
+                return new BooleanItem(false);
             }
             for (Item item : items) {
                 if (!item.isTypeOf(_sequenceType.getItemType())) {
-                    return new BooleanItem(false, ItemMetadata.fromIteratorMetadata(getMetadata()));
+                    return new BooleanItem(false);
                 }
             }
-            return new BooleanItem(true, ItemMetadata.fromIteratorMetadata(getMetadata()));
+            return new BooleanItem(true);
         } else
             throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE, getMetadata());
     }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/MultiplicativeOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/MultiplicativeOperationIterator.java
@@ -103,7 +103,7 @@ public class MultiplicativeOperationIterator extends BinaryOperationBaseIterator
                     }
                 } catch (IteratorFlowException e)
                 {
-                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+                    throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
 
                 }
             } else if (returnType.equals(DoubleItem.class)) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/MultiplicativeOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/MultiplicativeOperationIterator.java
@@ -103,8 +103,8 @@ public class MultiplicativeOperationIterator extends BinaryOperationBaseIterator
                     }
                 } catch (IteratorFlowException e)
                 {
-                    e.setMetadata(getMetadata().getExpressionMetadata());
-                    throw e;
+                    throw new IteratorFlowException(e.getMessage(), getMetadata());
+
                 }
             } else if (returnType.equals(DoubleItem.class)) {
                 double l = Item.<Double>getNumericValue(_left, Double.class);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/MultiplicativeOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/MultiplicativeOperationIterator.java
@@ -104,7 +104,6 @@ public class MultiplicativeOperationIterator extends BinaryOperationBaseIterator
                 } catch (IteratorFlowException e)
                 {
                     throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
-
                 }
             } else if (returnType.equals(DoubleItem.class)) {
                 double l = Item.<Double>getNumericValue(_left, Double.class);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/MultiplicativeOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/MultiplicativeOperationIterator.java
@@ -72,34 +72,40 @@ public class MultiplicativeOperationIterator extends BinaryOperationBaseIterator
 
             Type returnType = Item.getNumericResultType(_left, _right);
             if (returnType.equals(IntegerItem.class)) {
-                int l = Item.<Integer>getNumericValue(_left, Integer.class);
-                int r = Item.<Integer>getNumericValue(_right, Integer.class);
-                switch (this._operator) {
-                    case MUL:
-                        return new IntegerItem(l * r, ItemMetadata.fromIteratorMetadata(getMetadata()));
-                    case DIV:
-                        BigDecimal decLeft = Item.<BigDecimal>getNumericValue(_left, BigDecimal.class);
-                        BigDecimal decRight = Item.<BigDecimal>getNumericValue(_right, BigDecimal.class);
-                        BigDecimal bdResult = decLeft.divide(decRight, 10, BigDecimal.ROUND_HALF_UP);
-                        // if the result contains no decimal part, convert to integer
-                        if (bdResult.stripTrailingZeros().scale() <= 0) {
-                            try {
-                                // exception is thrown if information is lost during conversion to integer
-                                // this happens if the bigdecimal has a decimal part, or if it can't be fit to an integer
-                                return new IntegerItem(bdResult.intValueExact(), ItemMetadata.fromIteratorMetadata(getMetadata()));
-                            } catch (ArithmeticException e) {
-                                e.printStackTrace();
+                try {
+                    int l = Item.<Integer>getNumericValue(_left, Integer.class);
+                    int r = Item.<Integer>getNumericValue(_right, Integer.class);
+                    switch (this._operator) {
+                        case MUL:
+                            return new IntegerItem(l * r, ItemMetadata.fromIteratorMetadata(getMetadata()));
+                        case DIV:
+                            BigDecimal decLeft = Item.<BigDecimal>getNumericValue(_left, BigDecimal.class);
+                            BigDecimal decRight = Item.<BigDecimal>getNumericValue(_right, BigDecimal.class);
+                            BigDecimal bdResult = decLeft.divide(decRight, 10, BigDecimal.ROUND_HALF_UP);
+                            // if the result contains no decimal part, convert to integer
+                            if (bdResult.stripTrailingZeros().scale() <= 0) {
+                                try {
+                                    // exception is thrown if information is lost during conversion to integer
+                                    // this happens if the bigdecimal has a decimal part, or if it can't be fit to an integer
+                                    return new IntegerItem(bdResult.intValueExact(), ItemMetadata.fromIteratorMetadata(getMetadata()));
+                                } catch (ArithmeticException e) {
+                                    e.printStackTrace();
+                                }
+                            } else {
+                                return new DecimalItem(bdResult,
+                                        ItemMetadata.fromIteratorMetadata(getMetadata()));
                             }
-                        } else {
-                            return new DecimalItem(bdResult,
-                                    ItemMetadata.fromIteratorMetadata(getMetadata()));
-                        }
-                    case MOD:
-                        return new IntegerItem(l % r, ItemMetadata.fromIteratorMetadata(getMetadata()));
-                    case IDIV:
-                        return new IntegerItem(l / r, ItemMetadata.fromIteratorMetadata(getMetadata()));
-                    default:
-                        new IteratorFlowException("Non recognized multicative operator.", getMetadata());
+                        case MOD:
+                            return new IntegerItem(l % r, ItemMetadata.fromIteratorMetadata(getMetadata()));
+                        case IDIV:
+                            return new IntegerItem(l / r, ItemMetadata.fromIteratorMetadata(getMetadata()));
+                        default:
+                            new IteratorFlowException("Non recognized multicative operator.", getMetadata());
+                    }
+                } catch (IteratorFlowException e)
+                {
+                    e.setMetadata(getMetadata().getExpressionMetadata());
+                    throw e;
                 }
             } else if (returnType.equals(DoubleItem.class)) {
                 double l = Item.<Double>getNumericValue(_left, Double.class);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/MultiplicativeOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/MultiplicativeOperationIterator.java
@@ -77,7 +77,7 @@ public class MultiplicativeOperationIterator extends BinaryOperationBaseIterator
                     int r = Item.<Integer>getNumericValue(_right, Integer.class);
                     switch (this._operator) {
                         case MUL:
-                            return new IntegerItem(l * r, ItemMetadata.fromIteratorMetadata(getMetadata()));
+                            return new IntegerItem(l * r);
                         case DIV:
                             BigDecimal decLeft = Item.<BigDecimal>getNumericValue(_left, BigDecimal.class);
                             BigDecimal decRight = Item.<BigDecimal>getNumericValue(_right, BigDecimal.class);
@@ -87,18 +87,17 @@ public class MultiplicativeOperationIterator extends BinaryOperationBaseIterator
                                 try {
                                     // exception is thrown if information is lost during conversion to integer
                                     // this happens if the bigdecimal has a decimal part, or if it can't be fit to an integer
-                                    return new IntegerItem(bdResult.intValueExact(), ItemMetadata.fromIteratorMetadata(getMetadata()));
+                                    return new IntegerItem(bdResult.intValueExact());
                                 } catch (ArithmeticException e) {
                                     e.printStackTrace();
                                 }
                             } else {
-                                return new DecimalItem(bdResult,
-                                        ItemMetadata.fromIteratorMetadata(getMetadata()));
+                                return new DecimalItem(bdResult);
                             }
                         case MOD:
-                            return new IntegerItem(l % r, ItemMetadata.fromIteratorMetadata(getMetadata()));
+                            return new IntegerItem(l % r);
                         case IDIV:
-                            return new IntegerItem(l / r, ItemMetadata.fromIteratorMetadata(getMetadata()));
+                            return new IntegerItem(l / r);
                         default:
                             new IteratorFlowException("Non recognized multicative operator.", getMetadata());
                     }
@@ -112,13 +111,13 @@ public class MultiplicativeOperationIterator extends BinaryOperationBaseIterator
                 double r = Item.<Double>getNumericValue(_right, Double.class);
                 switch (this._operator) {
                     case MUL:
-                        return new DoubleItem(l * r, ItemMetadata.fromIteratorMetadata(getMetadata()));
+                        return new DoubleItem(l * r);
                     case DIV:
-                        return new DoubleItem(l / r, ItemMetadata.fromIteratorMetadata(getMetadata()));
+                        return new DoubleItem(l / r);
                     case MOD:
-                        return new DoubleItem(l % r, ItemMetadata.fromIteratorMetadata(getMetadata()));
+                        return new DoubleItem(l % r);
                     case IDIV:
-                        return new DoubleItem((int) (l / r), ItemMetadata.fromIteratorMetadata(getMetadata()));
+                        return new DoubleItem((int) (l / r));
                     default:
                         new IteratorFlowException("Non recognized multicative operator.", getMetadata());
                 }
@@ -127,14 +126,13 @@ public class MultiplicativeOperationIterator extends BinaryOperationBaseIterator
                 BigDecimal r = Item.<BigDecimal>getNumericValue(_right, BigDecimal.class);
                 switch (this._operator) {
                     case MUL:
-                        return new DecimalItem(l.multiply(r), ItemMetadata.fromIteratorMetadata(getMetadata()));
+                        return new DecimalItem(l.multiply(r));
                     case DIV:
-                        return new DecimalItem(l.divide(r, 10, BigDecimal.ROUND_HALF_UP),
-                                ItemMetadata.fromIteratorMetadata(getMetadata()));
+                        return new DecimalItem(l.divide(r, 10, BigDecimal.ROUND_HALF_UP));
                     case MOD:
-                        return new DecimalItem(l.remainder(r), ItemMetadata.fromIteratorMetadata(getMetadata()));
+                        return new DecimalItem(l.remainder(r));
                     case IDIV:
-                        return new DecimalItem(l.divideToIntegralValue(r), ItemMetadata.fromIteratorMetadata(getMetadata()));
+                        return new DecimalItem(l.divideToIntegralValue(r));
                     default:
                         new IteratorFlowException("Non recognized multicative operator.", getMetadata());
                 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/NotOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/NotOperationIterator.java
@@ -40,6 +40,6 @@ public class NotOperationIterator extends UnaryOperationBaseIterator {
         Item child = _child.next();
         _child.close();
         this._hasNext = false;
-        return new BooleanItem(!Item.getEffectiveBooleanValue(child), ItemMetadata.fromIteratorMetadata(getMetadata()));
+        return new BooleanItem(!Item.getEffectiveBooleanValue(child));
     }
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/OrOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/OrOperationIterator.java
@@ -49,7 +49,6 @@ public class OrOperationIterator extends BinaryOperationBaseIterator {
         _leftIterator.close();
         _rightIterator.close();
         this._hasNext = false;
-        return new BooleanItem(Item.getEffectiveBooleanValue(left) || Item.getEffectiveBooleanValue(right)
-                , ItemMetadata.fromIteratorMetadata(getMetadata()));
+        return new BooleanItem(Item.getEffectiveBooleanValue(left) || Item.getEffectiveBooleanValue(right));
     }
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/RangeOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/RangeOperationIterator.java
@@ -25,7 +25,6 @@ import sparksoniq.jsoniq.compiler.translator.expr.operational.base.OperationalEx
 import sparksoniq.jsoniq.item.AtomicItem;
 import sparksoniq.jsoniq.item.IntegerItem;
 import sparksoniq.jsoniq.item.Item;
-import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.operational.base.BinaryOperationBaseIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
@@ -46,7 +45,7 @@ public class RangeOperationIterator extends BinaryOperationBaseIterator {
         if(_hasNext == true){
             if (_index == _right)
                 this._hasNext = false;
-            return new IntegerItem(_index++, ItemMetadata.fromIteratorMetadata(getMetadata()));
+            return new IntegerItem(_index++);
         }
         throw new IteratorFlowException("Invalid next call in Range Operation", getMetadata());
     }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/RangeOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/RangeOperationIterator.java
@@ -69,7 +69,6 @@ public class RangeOperationIterator extends BinaryOperationBaseIterator {
             } catch (IteratorFlowException e)
             {
                 throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
-
             }
             if (_right < _left) {
                 this._hasNext = false;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/RangeOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/RangeOperationIterator.java
@@ -64,8 +64,14 @@ public class RangeOperationIterator extends BinaryOperationBaseIterator {
             if (_leftIterator.hasNext() || _rightIterator.hasNext() || !(left instanceof IntegerItem) || !(right instanceof IntegerItem))
                 throw new UnexpectedTypeException("Range expression has non numeric args " +
                         left.serialize() + ", " + right.serialize(), getMetadata());
-            _left = Item.getNumericValue(left, Integer.class);
-            _right = Item.getNumericValue(right, Integer.class);
+            try {
+                _left = Item.getNumericValue(left, Integer.class);
+                _right = Item.getNumericValue(right, Integer.class);
+            } catch (IteratorFlowException e)
+            {
+                e.setMetadata(getMetadata().getExpressionMetadata());
+                throw e;
+            }
             if (_right < _left) {
                 this._hasNext = false;
             } else {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/RangeOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/RangeOperationIterator.java
@@ -68,8 +68,8 @@ public class RangeOperationIterator extends BinaryOperationBaseIterator {
                 _right = Item.getNumericValue(right, Integer.class);
             } catch (IteratorFlowException e)
             {
-                e.setMetadata(getMetadata().getExpressionMetadata());
-                throw e;
+                throw new IteratorFlowException(e.getMessage(), getMetadata());
+
             }
             if (_right < _left) {
                 this._hasNext = false;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/RangeOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/RangeOperationIterator.java
@@ -68,7 +68,7 @@ public class RangeOperationIterator extends BinaryOperationBaseIterator {
                 _right = Item.getNumericValue(right, Integer.class);
             } catch (IteratorFlowException e)
             {
-                throw new IteratorFlowException(e.getMessage(), getMetadata());
+                throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
 
             }
             if (_right < _left) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/StringConcatIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/StringConcatIterator.java
@@ -25,7 +25,6 @@ import sparksoniq.jsoniq.compiler.translator.expr.operational.base.OperationalEx
 import sparksoniq.jsoniq.item.AtomicItem;
 import sparksoniq.jsoniq.item.Item;
 import sparksoniq.jsoniq.item.StringItem;
-import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.operational.base.BinaryOperationBaseIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
@@ -46,12 +45,12 @@ public class StringConcatIterator extends BinaryOperationBaseIterator {
             if (_leftIterator.hasNext()) {
                 left = _leftIterator.next();
             } else {
-                left = new StringItem("", ItemMetadata.fromIteratorMetadata(getMetadata()));
+                left = new StringItem("");
             }
             if (_rightIterator.hasNext()) {
                 right = _rightIterator.next();
             } else {
-                right = new StringItem("", ItemMetadata.fromIteratorMetadata(getMetadata()));
+                right = new StringItem("");
             }
             if (!(left.isAtomic()) || !(right.isAtomic()))
                 throw new UnexpectedTypeException("String concat expression has arguments that can't be converted to a string " +
@@ -63,8 +62,7 @@ public class StringConcatIterator extends BinaryOperationBaseIterator {
             _leftIterator.close();
             _rightIterator.close();
             this._hasNext = false;
-            return new StringItem(leftStringValue.concat(rightStringValue),
-                    ItemMetadata.fromIteratorMetadata(getMetadata()));
+            return new StringItem(leftStringValue.concat(rightStringValue));
         }
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE, getMetadata());
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/UnaryOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/UnaryOperationIterator.java
@@ -53,14 +53,11 @@ public class UnaryOperationIterator extends UnaryOperationBaseIterator {
             {
                 if(Item.isNumeric(child)){
                     if(child instanceof IntegerItem)
-                        return new IntegerItem(-1 * ((IntegerItem)child).getIntegerValue(),
-                                ItemMetadata.fromIteratorMetadata(getMetadata()));
+                        return new IntegerItem(-1 * ((IntegerItem)child).getIntegerValue());
                     if(child instanceof DoubleItem)
-                        return new DoubleItem(-1 * ((DoubleItem)child).getDoubleValue(),
-                                ItemMetadata.fromIteratorMetadata(getMetadata()));
+                        return new DoubleItem(-1 * ((DoubleItem)child).getDoubleValue());
                     if(child instanceof DecimalItem)
-                        return new DecimalItem(((DecimalItem)child).getDecimalValue().multiply(new BigDecimal(-1)),
-                                ItemMetadata.fromIteratorMetadata(getMetadata()));
+                        return new DecimalItem(((DecimalItem)child).getDecimalValue().multiply(new BigDecimal(-1)));
                 }
                 throw new UnexpectedTypeException("Unary expression has non numeric args " +
                         child.serialize(), getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ArrayLookupIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ArrayLookupIterator.java
@@ -87,8 +87,13 @@ public class ArrayLookupIterator extends HybridRuntimeIterator {
                     + lookupExpression.serialize(), getMetadata());
         }
         lookupIterator.close();
-
-        _lookup = Item.getNumericValue(lookupExpression, Integer.class);
+        try {
+            _lookup = Item.getNumericValue(lookupExpression, Integer.class);
+        } catch (IteratorFlowException e)
+        {
+            e.setMetadata(getMetadata().getExpressionMetadata());
+            throw e;
+        }
     }
 
     @Override

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ArrayLookupIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ArrayLookupIterator.java
@@ -91,8 +91,8 @@ public class ArrayLookupIterator extends HybridRuntimeIterator {
             _lookup = Item.getNumericValue(lookupExpression, Integer.class);
         } catch (IteratorFlowException e)
         {
-            e.setMetadata(getMetadata().getExpressionMetadata());
-            throw e;
+            throw new IteratorFlowException(e.getMessage(), getMetadata());
+
         }
     }
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ArrayLookupIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ArrayLookupIterator.java
@@ -91,7 +91,7 @@ public class ArrayLookupIterator extends HybridRuntimeIterator {
             _lookup = Item.getNumericValue(lookupExpression, Integer.class);
         } catch (IteratorFlowException e)
         {
-            throw new IteratorFlowException(e.getMessage(), getMetadata());
+            throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
 
         }
     }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ArrayLookupIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ArrayLookupIterator.java
@@ -92,7 +92,6 @@ public class ArrayLookupIterator extends HybridRuntimeIterator {
         } catch (IteratorFlowException e)
         {
             throw new IteratorFlowException(e.getJSONiqErrorMessage(), getMetadata());
-
         }
     }
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ObjectLookupIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ObjectLookupIterator.java
@@ -25,7 +25,6 @@ import sparksoniq.exceptions.InvalidSelectorException;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.exceptions.UnexpectedTypeException;
 import sparksoniq.jsoniq.item.*;
-import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.HybridRuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.primary.ContextExpressionIterator;
@@ -75,16 +74,16 @@ public class ObjectLookupIterator extends HybridRuntimeIterator {
                 // convert to string
                 if (_lookupKey.isBoolean()) {
                     Boolean value = ((BooleanItem)_lookupKey).getValue();
-                    _lookupKey = new StringItem(value.toString(), ItemMetadata.fromIteratorMetadata(getMetadata()));
+                    _lookupKey = new StringItem(value.toString());
                 } else if (_lookupKey.isDecimal()) {
                     BigDecimal value = ((DecimalItem)_lookupKey).getValue();
-                    _lookupKey = new StringItem(value.toString(), ItemMetadata.fromIteratorMetadata(getMetadata()));
+                    _lookupKey = new StringItem(value.toString());
                 } else if (_lookupKey.isDouble()) {
                     Double value = ((DoubleItem)_lookupKey).getValue();
-                    _lookupKey = new StringItem(value.toString(), ItemMetadata.fromIteratorMetadata(getMetadata()));
+                    _lookupKey = new StringItem(value.toString());
                 } else if (_lookupKey.isInteger()) {
                     Integer value = ((IntegerItem)_lookupKey).getValue();
-                    _lookupKey = new StringItem(value.toString(), ItemMetadata.fromIteratorMetadata(getMetadata()));
+                    _lookupKey = new StringItem(value.toString());
                 } else if (_lookupKey.isString()) {
                     // do nothing
                 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ArrayRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ArrayRuntimeIterator.java
@@ -42,7 +42,7 @@ public class ArrayRuntimeIterator extends LocalRuntimeIterator {
     public ArrayItem next() {
         if(this._hasNext) {
             List<Item> result = this.runChildrenIterators(this._currentDynamicContext);
-            this._item = new ArrayItem(result, ItemMetadata.fromIteratorMetadata(getMetadata()));
+            this._item = new ArrayItem(result);
             this._hasNext = false;
             return _item;
         }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/BooleanRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/BooleanRuntimeIterator.java
@@ -30,7 +30,7 @@ public class BooleanRuntimeIterator extends AtomicRuntimeIterator {
     public BooleanItem next() {
         if (this._hasNext) {
             this._hasNext = false;
-            return new BooleanItem(_item, ItemMetadata.fromIteratorMetadata(getMetadata()));
+            return new BooleanItem(_item);
         }
 
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + this._item, getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/DecimalRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/DecimalRuntimeIterator.java
@@ -33,7 +33,7 @@ public class DecimalRuntimeIterator extends AtomicRuntimeIterator {
     public DecimalItem next() {
         if (this._hasNext) {
             this._hasNext = false;
-            return new DecimalItem(_item, ItemMetadata.fromIteratorMetadata(getMetadata()));
+            return new DecimalItem(_item);
         }
 
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + this._item, getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/DoubleRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/DoubleRuntimeIterator.java
@@ -31,7 +31,7 @@ public class DoubleRuntimeIterator extends AtomicRuntimeIterator{
     public DoubleItem next() {
         if (this._hasNext) {
             this._hasNext = false;
-            return new DoubleItem(_item, ItemMetadata.fromIteratorMetadata(getMetadata()));
+            return new DoubleItem(_item);
         }
 
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + this._item, getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/IntegerRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/IntegerRuntimeIterator.java
@@ -21,7 +21,6 @@
 
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.jsoniq.item.IntegerItem;
-import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 
@@ -31,7 +30,7 @@ public class IntegerRuntimeIterator extends AtomicRuntimeIterator {
     public IntegerItem next() {
         if (this._hasNext) {
             this._hasNext = false;
-            return new IntegerItem(_item, ItemMetadata.fromIteratorMetadata(getMetadata()));
+            return new IntegerItem(_item);
         }
 
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + this._item, getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/NullRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/NullRuntimeIterator.java
@@ -36,7 +36,7 @@ public class NullRuntimeIterator extends AtomicRuntimeIterator {
     public AtomicItem next() {
         if (this._hasNext) {
             this._hasNext = false;
-            return new NullItem(ItemMetadata.fromIteratorMetadata(getMetadata()));
+            return new NullItem();
         }
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + "\"null\"", getMetadata());
     }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ObjectConstructorRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ObjectConstructorRuntimeIterator.java
@@ -80,7 +80,7 @@ public class ObjectConstructorRuntimeIterator extends LocalRuntimeIterator {
                     valueIterator.close();
                     //SIMILAR TO ZORBA, if value is more than one item, wrap it in an array
                     if (currentResults.size() > 1)
-                        values.add(new ArrayItem(currentResults, ItemMetadata.fromIteratorMetadata(getMetadata())));
+                        values.add(new ArrayItem(currentResults));
                     else
                         values.add(currentResults.get(0));
                 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/StringRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/StringRuntimeIterator.java
@@ -21,7 +21,6 @@
 
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.jsoniq.item.StringItem;
-import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 
@@ -31,7 +30,7 @@ public class StringRuntimeIterator extends AtomicRuntimeIterator {
     public StringItem next() {
         if (this._hasNext) {
             this._hasNext = false;
-            return new StringItem(_item, ItemMetadata.fromIteratorMetadata(getMetadata()));
+            return new StringItem(_item);
         }
 
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + this._item, getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/quantifiers/QuantifiedExpressionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/quantifiers/QuantifiedExpressionIterator.java
@@ -69,7 +69,7 @@ public class QuantifiedExpressionIterator extends LocalRuntimeIterator {
             for (BooleanItem res : results)
                 result = this._operator == QuantifiedExpression.QuantifiedOperators.EVERY ?
                         result && res.getBooleanValue() : result || res.getBooleanValue();
-            return new BooleanItem(result, ItemMetadata.fromIteratorMetadata(getMetadata()));
+            return new BooleanItem(result);
         }
         throw new IteratorFlowException(RuntimeIterator.FLOW_EXCEPTION_MESSAGE + "Quantified Expr", getMetadata());
     }

--- a/src/main/java/sparksoniq/spark/closures/CountClauseClosure.java
+++ b/src/main/java/sparksoniq/spark/closures/CountClauseClosure.java
@@ -3,7 +3,6 @@ package sparksoniq.spark.closures;
 import org.apache.spark.api.java.function.Function;
 import scala.Tuple2;
 import sparksoniq.jsoniq.item.IntegerItem;
-import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.jsoniq.tuple.FlworTuple;
 
@@ -21,7 +20,7 @@ public class CountClauseClosure implements Function<Tuple2<FlworTuple, Long>, Fl
         FlworTuple result = inputTuple._1;
         result.putValue(
                 variableName,
-                new IntegerItem(inputTuple._2.intValue(), ItemMetadata.fromIteratorMetadata(metadata)),
+                new IntegerItem(inputTuple._2.intValue()),
                 true
         );
         return result;


### PR DESCRIPTION
To further improve performance, I reduced the memory footprint of items by removing item metadata -- instead, the metadata is set by the iterators directly (which is also more correct, as it is the iterator's line number and column number that shows where the error is, not where the item was created). No change to the tests was needed and all line and column numbers are unchanged.

Now items have the bare minimum: only one field for atomic items, just a list for arrays, just two lists for objects.

This improved the quantity of data I am able to group by on a single machine by 50% (Went from 400k to 600k objects).