### PR TITLE
Data Frames Primer w/ For and Return Clauses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
          <dependency>
              <groupId>com.esotericsoftware</groupId>
              <artifactId>kryo</artifactId>
-             <version>4.0.0</version>
+             <version>5.0.0-RC2</version>
          </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_2.11</artifactId>
-            <version>2.2.1</version>
+            <version>2.4.0</version>
             <scope>provided</scope>
         </dependency>
          <dependency>

--- a/src/main/java/sparksoniq/jsoniq/item/ArrayItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/ArrayItem.java
@@ -17,7 +17,7 @@
  * Author: Stefan Irimescu
  *
  */
- package sparksoniq.jsoniq.item;
+package sparksoniq.jsoniq.item;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
@@ -36,7 +36,11 @@ public class ArrayItem extends JsonItem {
         return _arrayItems;
     }
 
-    public ArrayItem(List<Item> arrayItems){
+    protected ArrayItem() {
+        super();
+    }
+
+    public ArrayItem(List<Item> arrayItems) {
         super();
         this._arrayItems = arrayItems;
     }
@@ -52,7 +56,9 @@ public class ArrayItem extends JsonItem {
     }
 
     @Override
-    public void putItem(Item value) { this._arrayItems.add(value); }
+    public void putItem(Item value) {
+        this._arrayItems.add(value);
+    }
 
     @Override
     public void putItemByKey(String s, Item value) throws OperationNotSupportedException {
@@ -71,15 +77,18 @@ public class ArrayItem extends JsonItem {
 
 
     @Override
-    public  boolean isArray(){ return true; }
+    public boolean isArray() {
+        return true;
+    }
 
     @Override
     public int getSize() {
         return this._arrayItems.size();
     }
 
-    @Override public boolean isTypeOf(ItemType type) {
-        if(type.getType().equals(ItemTypes.ArrayItem) || super.isTypeOf(type))
+    @Override
+    public boolean isTypeOf(ItemType type) {
+        if (type.getType().equals(ItemTypes.ArrayItem) || super.isTypeOf(type))
             return true;
         return false;
     }
@@ -88,7 +97,7 @@ public class ArrayItem extends JsonItem {
     public String serialize() {
         String result = "[ ";
         for (Item item : this._arrayItems)
-            result += item.serialize() + (_arrayItems.indexOf(item) < _arrayItems.size() -1 ? ", " : " ");
+            result += item.serialize() + (_arrayItems.indexOf(item) < _arrayItems.size() - 1 ? ", " : " ");
         result += "]";
         return result;
     }

--- a/src/main/java/sparksoniq/jsoniq/item/BooleanItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/BooleanItem.java
@@ -34,6 +34,10 @@ public class BooleanItem extends AtomicItem {
         return _value;
     }
 
+    protected BooleanItem() {
+        super();
+    }
+
     public BooleanItem(boolean value){
         super();
         this._value = value;

--- a/src/main/java/sparksoniq/jsoniq/item/DecimalItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/DecimalItem.java
@@ -17,7 +17,7 @@
  * Author: Stefan Irimescu
  *
  */
- package sparksoniq.jsoniq.item;
+package sparksoniq.jsoniq.item;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
@@ -35,7 +35,11 @@ public class DecimalItem extends AtomicItem {
         return _value;
     }
 
-    public DecimalItem(BigDecimal decimal){
+    protected DecimalItem() {
+        super();
+    }
+
+    public DecimalItem(BigDecimal decimal) {
         super();
         this._value = decimal;
     }
@@ -66,10 +70,13 @@ public class DecimalItem extends AtomicItem {
     }
 
     @Override
-    public  boolean isDecimal(){ return true; }
+    public boolean isDecimal() {
+        return true;
+    }
 
-    @Override public boolean isTypeOf(ItemType type) {
-        if(type.getType().equals(ItemTypes.DecimalItem)|| super.isTypeOf(type))
+    @Override
+    public boolean isTypeOf(ItemType type) {
+        if (type.getType().equals(ItemTypes.DecimalItem) || super.isTypeOf(type))
             return true;
         return false;
     }

--- a/src/main/java/sparksoniq/jsoniq/item/DoubleItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/DoubleItem.java
@@ -34,6 +34,10 @@ public class DoubleItem extends AtomicItem {
         return _value;
     }
 
+    protected DoubleItem() {
+        super();
+    }
+
     public DoubleItem(double value){
         super();
         this._value = value;

--- a/src/main/java/sparksoniq/jsoniq/item/IntegerItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/IntegerItem.java
@@ -34,6 +34,10 @@ public class IntegerItem extends AtomicItem {
         return _value;
     }
 
+    public IntegerItem() {
+        super();
+    }
+
     public IntegerItem(int value){
         super();
         this._value =value;

--- a/src/main/java/sparksoniq/jsoniq/item/KryoManager.java
+++ b/src/main/java/sparksoniq/jsoniq/item/KryoManager.java
@@ -1,13 +1,20 @@
 package sparksoniq.jsoniq.item;
 
 import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.ByteBufferInput;
+import com.esotericsoftware.kryo.io.ByteBufferOutput;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import com.esotericsoftware.kryo.util.Pool;
 
 import java.util.ArrayList;
 
 public class KryoManager {
 
     private static KryoManager _instance;
-    private Kryo kryo;
+    private Pool<Kryo> kryoPool;
+    private Pool<Output> outputPool;
+    private Pool<Input> inputPool;
 
     public static KryoManager getInstance() {
         if (_instance == null)
@@ -19,30 +26,74 @@ public class KryoManager {
     }
 
     public Kryo getOrCreateKryo() {
-        if (kryo == null) {
-            kryo = new Kryo();
-            kryo.register(Item.class);
-            kryo.register(ArrayItem.class);
-            kryo.register(ObjectItem.class);
-            kryo.register(StringItem.class);
-            kryo.register(IntegerItem.class);
-            kryo.register(DoubleItem.class);
-            kryo.register(DecimalItem.class);
-            kryo.register(NullItem.class);
-            kryo.register(BooleanItem.class);
+        if (kryoPool == null) {
+            // 3rd param: max capacity is omitted for no limit
+            kryoPool = new Pool<Kryo>(true, false) {
+                @Override
+                protected Kryo create() {
+                    Kryo kryo = new Kryo();
+                    kryo.register(Item.class);
+                    kryo.register(ArrayItem.class);
+                    kryo.register(ObjectItem.class);
+                    kryo.register(StringItem.class);
+                    kryo.register(IntegerItem.class);
+                    kryo.register(DoubleItem.class);
+                    kryo.register(DecimalItem.class);
+                    kryo.register(NullItem.class);
+                    kryo.register(BooleanItem.class);
 
-            kryo.register(ArrayList.class);
+                    kryo.register(ArrayList.class);
 
+                    /*kryo.register(DynamicContext.class);
+                    kryo.register(FlworTuple.class);
+                    kryo.register(FlworKey.class);
+                    kryo.register(SparkRuntimeTupleIterator.class);
+                    kryo.register(RuntimeIterator.class);
+                    kryo.register(RuntimeTupleIterator.class);*/
 
-            /*kryo.register(DynamicContext.class);
-            kryo.register(FlworTuple.class);
-            kryo.register(FlworKey.class);
-            kryo.register(SparkRuntimeTupleIterator.class);
-            kryo.register(RuntimeIterator.class);
-            kryo.register(RuntimeTupleIterator.class);*/
-
-
+                    return kryo;
+                }
+            };
         }
-        return kryo;
+        return kryoPool.obtain();
+    }
+
+    public void releaseKryoInstance(Kryo kryo) {
+        kryoPool.free(kryo);
+    }
+
+    public Output getOrCreateOutput() {
+        if (outputPool == null) {
+            // 3rd param: max capacity is omitted for no limit
+            outputPool = new Pool<Output>(true, false) {
+                @Override
+                protected Output create() {
+                    return new Output(1024, -1);
+                }
+            };
+        }
+
+        return outputPool.obtain();
+    }
+
+    public void releaseOutputInstance(Output output) {
+        outputPool.free(output);
+    }
+
+    public Input getOrCreateInput() {
+        if (inputPool == null) {
+            // 3rd param: max capacity is omitted for no limit
+            inputPool = new Pool<Input>(true, false) {
+                @Override
+                protected Input create() {
+                    return new Input();
+                }
+            };
+        }
+        return inputPool.obtain();
+    }
+
+    public void releaseInputInstance(Input input) {
+        inputPool.free(input);
     }
 }

--- a/src/main/java/sparksoniq/jsoniq/item/KryoManager.java
+++ b/src/main/java/sparksoniq/jsoniq/item/KryoManager.java
@@ -1,0 +1,48 @@
+package sparksoniq.jsoniq.item;
+
+import com.esotericsoftware.kryo.Kryo;
+
+import java.util.ArrayList;
+
+public class KryoManager {
+
+    private static KryoManager _instance;
+    private Kryo kryo;
+
+    public static KryoManager getInstance() {
+        if (_instance == null)
+            _instance = new KryoManager();
+        return _instance;
+    }
+
+    private KryoManager() {
+    }
+
+    public Kryo getOrCreateKryo() {
+        if (kryo == null) {
+            kryo = new Kryo();
+            kryo.register(Item.class);
+            kryo.register(ArrayItem.class);
+            kryo.register(ObjectItem.class);
+            kryo.register(StringItem.class);
+            kryo.register(IntegerItem.class);
+            kryo.register(DoubleItem.class);
+            kryo.register(DecimalItem.class);
+            kryo.register(NullItem.class);
+            kryo.register(BooleanItem.class);
+
+            kryo.register(ArrayList.class);
+
+
+            /*kryo.register(DynamicContext.class);
+            kryo.register(FlworTuple.class);
+            kryo.register(FlworKey.class);
+            kryo.register(SparkRuntimeTupleIterator.class);
+            kryo.register(RuntimeIterator.class);
+            kryo.register(RuntimeTupleIterator.class);*/
+
+
+        }
+        return kryo;
+    }
+}

--- a/src/main/java/sparksoniq/jsoniq/item/NullItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/NullItem.java
@@ -17,7 +17,7 @@
  * Author: Stefan Irimescu
  *
  */
- package sparksoniq.jsoniq.item;
+package sparksoniq.jsoniq.item;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
@@ -28,7 +28,9 @@ import java.math.BigDecimal;
 
 public class NullItem extends AtomicItem {
 
-    public NullItem(){super();}
+    public NullItem() {
+        super();
+    }
 
     @Override
     public String getStringValue() throws OperationNotSupportedException {
@@ -62,7 +64,7 @@ public class NullItem extends AtomicItem {
 
     @Override
     public void write(Kryo kryo, Output output) {
-        kryo.writeObjectOrNull(output,null, Item.class);
+        kryo.writeObjectOrNull(output, null, Item.class);
     }
 
     @Override

--- a/src/main/java/sparksoniq/jsoniq/item/ObjectItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/ObjectItem.java
@@ -42,6 +42,10 @@ public class ObjectItem extends JsonItem{
         return _values;
     }
 
+    protected ObjectItem() {
+        super();
+    }
+
     public ObjectItem(List<String> keys, List<Item> values, ItemMetadata itemMetadata){
         super();
         checkForDuplicateKeys(keys, itemMetadata);

--- a/src/main/java/sparksoniq/jsoniq/item/StringItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/StringItem.java
@@ -17,7 +17,7 @@
  * Author: Stefan Irimescu
  *
  */
- package sparksoniq.jsoniq.item;
+package sparksoniq.jsoniq.item;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
@@ -28,13 +28,17 @@ import sparksoniq.semantics.types.ItemTypes;
 import javax.naming.OperationNotSupportedException;
 import java.math.BigDecimal;
 
-public class StringItem extends AtomicItem{
+public class StringItem extends AtomicItem {
 
     public String getValue() {
         return _value;
     }
 
-    public StringItem(String value){
+    protected StringItem() {
+        super();
+    }
+    
+    public StringItem(String value) {
         super();
         this._value = value;
     }
@@ -64,14 +68,17 @@ public class StringItem extends AtomicItem{
         throw new OperationNotSupportedException("String value exception");
     }
 
-    @Override public boolean isTypeOf(ItemType type) {
-        if(type.getType().equals(ItemTypes.StringItem) || super.isTypeOf(type))
+    @Override
+    public boolean isTypeOf(ItemType type) {
+        if (type.getType().equals(ItemTypes.StringItem) || super.isTypeOf(type))
             return true;
         return false;
     }
 
     @Override
-    public  boolean isString(){ return true; }
+    public boolean isString() {
+        return true;
+    }
 
     @Override
     public String serialize() {
@@ -88,5 +95,5 @@ public class StringItem extends AtomicItem{
         this._value = input.readString();
     }
 
-    private  String _value;
+    private String _value;
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/HybridRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/HybridRuntimeIterator.java
@@ -22,6 +22,7 @@
 import org.apache.spark.api.java.JavaRDD;
 import sparksoniq.ShellStart;
 import sparksoniq.exceptions.IteratorFlowException;
+import sparksoniq.exceptions.SparkRuntimeException;
 import sparksoniq.io.json.JiqsItemParser;
 import sparksoniq.jsoniq.item.Item;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
@@ -46,6 +47,16 @@ public abstract class HybridRuntimeIterator extends RuntimeIterator {
           isRDDInitialized = true;
         }
         return _isRDD;
+    }
+
+    @Override
+    public boolean isDataFrame() {
+        return false;
+    }
+
+    @Override
+    public boolean getDataFrame() {
+        throw new SparkRuntimeException("Iterator has no DataFrames", getMetadata());
     }
 
     @Override

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/RuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/RuntimeIterator.java
@@ -104,6 +104,10 @@ public abstract class RuntimeIterator implements RuntimeIteratorInterface, KryoS
 
     public abstract JavaRDD<Item> getRDD(DynamicContext dynamicContext);
 
+    public abstract boolean isDataFrame();
+
+    public abstract boolean getDataFrame();
+
     public abstract Item next();
 
     protected List<Item> runChildrenIterators(DynamicContext context) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/SparkRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/SparkRuntimeIterator.java
@@ -22,6 +22,7 @@
 import org.apache.spark.api.java.JavaRDD;
 import sparksoniq.ShellStart;
 import sparksoniq.exceptions.IteratorFlowException;
+import sparksoniq.exceptions.SparkRuntimeException;
 import sparksoniq.io.json.JiqsItemParser;
 import sparksoniq.jsoniq.item.Item;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
@@ -41,6 +42,16 @@ public abstract class SparkRuntimeIterator extends RuntimeIterator {
     public boolean isRDD()
     {
         return true;
+    }
+
+    @Override
+    public boolean isDataFrame() {
+        return false;
+    }
+
+    @Override
+    public boolean getDataFrame() {
+        throw new SparkRuntimeException("Iterator has no DataFrames", getMetadata());
     }
 
     @Override

--- a/src/main/java/sparksoniq/jsoniq/runtime/tupleiterator/RuntimeTupleIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/tupleiterator/RuntimeTupleIterator.java
@@ -24,6 +24,8 @@ import com.esotericsoftware.kryo.KryoSerializable;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.jsoniq.tuple.FlworTuple;
@@ -96,5 +98,8 @@ public abstract class RuntimeTupleIterator implements RuntimeTupleIteratorInterf
 
     public abstract JavaRDD<FlworTuple> getRDD(DynamicContext context);
 
+    public abstract boolean isDataFrame();
+
+    public abstract Dataset<Row> getDataFrame(DynamicContext context);
 
 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/tupleiterator/SparkRuntimeTupleIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/tupleiterator/SparkRuntimeTupleIterator.java
@@ -20,6 +20,8 @@
 package sparksoniq.jsoniq.runtime.tupleiterator;
 
 import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.io.json.JiqsItemParser;
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
@@ -75,6 +77,7 @@ public abstract class SparkRuntimeTupleIterator extends RuntimeTupleIterator {
 
     protected JiqsItemParser parser;
     protected JavaRDD<FlworTuple> _rdd;
+    protected Dataset<Row> _df;
     protected List<FlworTuple> result = null;
     protected int currentResultIndex = 0;
 }

--- a/src/main/java/sparksoniq/jsoniq/tuple/FlworTuple.java
+++ b/src/main/java/sparksoniq/jsoniq/tuple/FlworTuple.java
@@ -32,11 +32,11 @@ import java.util.*;
 public class FlworTuple implements Serializable, KryoSerializable{
 
     public FlworTuple(){
-        variables = new HashMap<>(1, 1);
+        variables = new LinkedHashMap<>(1, 1);
     }
 
     public FlworTuple(int nb){
-        variables = new HashMap<>(nb, 1);
+        variables = new LinkedHashMap<>(nb, 1);
     }
 
     /**
@@ -44,7 +44,7 @@ public class FlworTuple implements Serializable, KryoSerializable{
      * @param toCopy original tuple
      */
     public FlworTuple(FlworTuple toCopy){
-        variables = new HashMap<>(toCopy.getKeys().size(), 1);
+        variables = new LinkedHashMap<>(toCopy.getKeys().size(), 1);
         for(String key: toCopy.getKeys())
             this.putValue(key, toCopy.getValue(key), true);
     }
@@ -109,9 +109,9 @@ public class FlworTuple implements Serializable, KryoSerializable{
 
     @Override
     public void read(Kryo kryo, Input input) {
-        variables = kryo.readObject(input, HashMap.class);
+        variables = kryo.readObject(input, LinkedHashMap.class);
     }
 
-    private Map<String, List<Item>> variables;
+    private LinkedHashMap<String, List<Item>> variables;
 
 }

--- a/src/main/java/sparksoniq/spark/SparkSessionManager.java
+++ b/src/main/java/sparksoniq/spark/SparkSessionManager.java
@@ -5,7 +5,6 @@ import org.apache.log4j.Logger;
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SparkSession;
-import sparksoniq.exceptions.SparkRuntimeException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
 import sparksoniq.jsoniq.item.*;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
@@ -40,7 +39,7 @@ public class SparkSessionManager {
     private SparkSessionManager() {
     }
 
-    public SparkSession getSession() {
+    public SparkSession getOrCreateSession() {
         if (session == null) {
             if (this.configuration == null) {
                 setDefaultConfiguration();
@@ -91,7 +90,7 @@ public class SparkSessionManager {
 
     public JavaSparkContext getJavaSparkContext() {
         if (javaSparkContext == null) {
-            javaSparkContext = JavaSparkContext.fromSparkContext(this.getSession().sparkContext());
+            javaSparkContext = JavaSparkContext.fromSparkContext(this.getOrCreateSession().sparkContext());
         }
         return javaSparkContext;
     }

--- a/src/main/java/sparksoniq/spark/closures/ClosureUtils.java
+++ b/src/main/java/sparksoniq/spark/closures/ClosureUtils.java
@@ -1,0 +1,38 @@
+package sparksoniq.spark.closures;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import org.apache.spark.sql.Row;
+import sparksoniq.jsoniq.item.Item;
+import sparksoniq.jsoniq.item.KryoManager;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+public class ClosureUtils {
+
+    public static byte[] serializeItemList(List<Item> toSerialize) {
+        Kryo kryo = KryoManager.getInstance().getOrCreateKryo();
+
+        Output output = new Output(new ByteArrayOutputStream());
+        kryo.writeClassAndObject(output, toSerialize);
+        output.close();
+
+        byte[] byteArray = output.getBuffer();
+        return byteArray;
+    }
+
+    public static Object deserializeRow(Row row) {
+        Input input = new Input(new ByteArrayInputStream((byte[])row.get(0)));
+
+        Kryo kryo = KryoManager.getInstance().getOrCreateKryo();
+
+        Object obj = kryo.readClassAndObject(input);
+        input.close();
+
+        return obj;
+    }
+
+}

--- a/src/main/java/sparksoniq/spark/closures/ClosureUtils.java
+++ b/src/main/java/sparksoniq/spark/closures/ClosureUtils.java
@@ -9,30 +9,54 @@ import sparksoniq.jsoniq.item.KryoManager;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
 import java.util.List;
 
 public class ClosureUtils {
 
+    private static KryoManager KM = KryoManager.getInstance();
+
     public static byte[] serializeItemList(List<Item> toSerialize) {
-        Kryo kryo = KryoManager.getInstance().getOrCreateKryo();
+        Kryo kryo = KM.getOrCreateKryo();
 
         Output output = new Output(new ByteArrayOutputStream());
         kryo.writeClassAndObject(output, toSerialize);
         output.close();
 
         byte[] byteArray = output.getBuffer();
+
+        KM.releaseKryoInstance(kryo);
+
         return byteArray;
     }
 
-    public static Object deserializeRow(Row row) {
-        Input input = new Input(new ByteArrayInputStream((byte[])row.get(0)));
+    public static Object deserializeRowColumn(Row row, int columnIndex) {
+        Kryo kryo = KM.getOrCreateKryo();
 
-        Kryo kryo = KryoManager.getInstance().getOrCreateKryo();
+        Input input = new Input(new ByteArrayInputStream((byte[])row.get(columnIndex)));
 
         Object obj = kryo.readClassAndObject(input);
         input.close();
 
+        KM.releaseKryoInstance(kryo);
+
         return obj;
+    }
+
+
+    public static List<Object> deserializeEntireRow(Row row) {
+        Kryo kryo = KM.getOrCreateKryo();
+
+        ArrayList<Object> deserializedColumnObjects = new ArrayList<>();
+        for (int columnIndex = 0; columnIndex < row.length(); columnIndex++) {
+            Input input = new Input(new ByteArrayInputStream((byte[])row.get(columnIndex)));
+            Object deserializedColumnObject = kryo.readClassAndObject(input);
+            deserializedColumnObjects.add(deserializedColumnObject);
+            input.close();
+        }
+
+        KM.releaseKryoInstance(kryo);
+        return deserializedColumnObjects;
     }
 
 }

--- a/src/main/java/sparksoniq/spark/closures/ForClauseDeserializeClosure.java
+++ b/src/main/java/sparksoniq/spark/closures/ForClauseDeserializeClosure.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Stefan Irimescu
+ *
+ */
+package sparksoniq.spark.closures;
+
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.api.java.function.MapFunction;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import sparksoniq.jsoniq.item.Item;
+import sparksoniq.spark.SparkSessionManager;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class ForClauseDeserializeClosure implements MapFunction<Row, Row> {
+
+    public ForClauseDeserializeClosure() {
+    }
+
+    /**
+     * @param row
+     * @return List<Item>iterator, deserialized from parametrized Row object containing the List<Item>
+     */
+    @Override
+    public Row call(Row row) {
+        List<Object> deserializedRow = ClosureUtils.deserializeEntireRow(row);
+        List<List<Item>> allColumns = new ArrayList<>();
+        for (Object columnObject:deserializedRow) {
+            List<Item> column = (List<Item>) columnObject;
+            allColumns.add(column);
+        }
+        return RowFactory.create(allColumns);
+    }
+}

--- a/src/main/java/sparksoniq/spark/closures/ForClauseFlatMapClosure.java
+++ b/src/main/java/sparksoniq/spark/closures/ForClauseFlatMapClosure.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Stefan Irimescu
+ *
+ */
+package sparksoniq.spark.closures;
+
+import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.api.java.function.MapFunction;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.types.StructType;
+import sparksoniq.jsoniq.item.Item;
+import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
+import sparksoniq.semantics.DynamicContext;
+import sparksoniq.spark.SparkSessionManager;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class ForClauseFlatMapClosure implements FlatMapFunction<Row, Row> {
+    RuntimeIterator _expression;
+
+    public ForClauseFlatMapClosure(RuntimeIterator expression) {
+        this._expression = expression;
+    }
+
+    @Override
+    public Iterator<Row> call(Row row) {
+        StructType schema = row.schema();
+        String[] columnNames = schema.fieldNames();
+
+        // Deserialize row
+        List<Object> deserializedRow = ClosureUtils.deserializeEntireRow(row);
+        List<List<Item>> rowColumns = new ArrayList<>();
+        for (Object columnObject:deserializedRow) {
+            List<Item> column = (List<Item>) columnObject;
+            rowColumns.add(column);
+        }
+
+        // Create dynamic context with deserialized data
+        DynamicContext context = new DynamicContext();
+        for (int columnIndex = 0; columnIndex < columnNames.length; columnIndex++) {
+            context.addVariableValue(columnNames[columnIndex], rowColumns.get(columnIndex));
+        }
+
+        // Apply expression to the context
+        List<Row> results = new ArrayList<>();
+        _expression.open(context);
+        while (_expression.hasNext()) {
+            Item nextItem = _expression.next();
+            List<Item> newColumn = new ArrayList<>();
+            newColumn.add(nextItem);
+
+            List<byte[]> newRowColumns = new ArrayList<>();
+            for (List<Item> column:rowColumns) {
+                newRowColumns.add(ClosureUtils.serializeItemList(column));
+            }
+            newRowColumns.add(ClosureUtils.serializeItemList(newColumn));
+
+            results.add(RowFactory.create(newRowColumns.toArray()));
+        }
+        _expression.close();
+
+        return results.iterator();
+    }
+}

--- a/src/main/java/sparksoniq/spark/closures/ForClauseSerializeClosure.java
+++ b/src/main/java/sparksoniq/spark/closures/ForClauseSerializeClosure.java
@@ -17,37 +17,30 @@
  * Author: Stefan Irimescu
  *
  */
- package sparksoniq.jsoniq.runtime.iterator;
+package sparksoniq.spark.closures;
 
-import org.apache.spark.api.java.JavaRDD;
-import sparksoniq.exceptions.SparkRuntimeException;
+import org.apache.spark.api.java.function.Function;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
 import sparksoniq.jsoniq.item.Item;
-import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
-import sparksoniq.semantics.DynamicContext;
 
+import java.util.ArrayList;
 import java.util.List;
 
-public abstract class LocalRuntimeIterator extends RuntimeIterator {
-    protected LocalRuntimeIterator(List<RuntimeIterator> children, IteratorMetadata iteratorMetadata) {
-        super(children, iteratorMetadata);
+public class ForClauseSerializeClosure implements Function<Item, Row> {
+
+    public ForClauseSerializeClosure() {
     }
 
+    /**
+     * @param item
+     * @return Row object, containing byte array of a singleton list containing the given item
+     */
     @Override
-    public JavaRDD<Item> getRDD(DynamicContext dynamicContext)
-    {
-        throw new SparkRuntimeException("Iterator has no RDDs", getMetadata());
-    }
+    public Row call(Item item) throws Exception {
+        List<Item> itemList = new ArrayList<>();
+        itemList.add(item);
 
-    @Override
-    public boolean isRDD(){ return false; }
-
-    @Override
-    public boolean isDataFrame() {
-        return false;
-    }
-
-    @Override
-    public boolean getDataFrame() {
-        throw new SparkRuntimeException("Iterator has no DataFrames", getMetadata());
+        return RowFactory.create(ClosureUtils.serializeItemList(itemList));
     }
 }

--- a/src/main/java/sparksoniq/spark/closures/OLD_ForClauseLocalToRDDClosure.java
+++ b/src/main/java/sparksoniq/spark/closures/OLD_ForClauseLocalToRDDClosure.java
@@ -23,12 +23,12 @@ import org.apache.spark.api.java.function.Function;
 import sparksoniq.jsoniq.item.Item;
 import sparksoniq.jsoniq.tuple.FlworTuple;
 
-public class ForClauseLocalToRDDClosure implements Function<Item, FlworTuple> {
+public class OLD_ForClauseLocalToRDDClosure implements Function<Item, FlworTuple> {
     private final String _variableName;
     private final FlworTuple _inputTuple;
 
 
-    public ForClauseLocalToRDDClosure(String variableName, FlworTuple inputTuple) {
+    public OLD_ForClauseLocalToRDDClosure(String variableName, FlworTuple inputTuple) {
         this._variableName = variableName;
         this._inputTuple = inputTuple;
     }

--- a/src/main/java/sparksoniq/spark/closures/OLD_ReturnFlatMapClosure.java
+++ b/src/main/java/sparksoniq/spark/closures/OLD_ReturnFlatMapClosure.java
@@ -20,25 +20,29 @@
 package sparksoniq.spark.closures;
 
 import org.apache.spark.api.java.function.FlatMapFunction;
-import org.apache.spark.sql.Row;
 import sparksoniq.jsoniq.item.Item;
+import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
+import sparksoniq.jsoniq.tuple.FlworTuple;
+import sparksoniq.semantics.DynamicContext;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-public class ReturnClauseDeserializeClosure implements FlatMapFunction<Row, Item> {
+public class OLD_ReturnFlatMapClosure implements FlatMapFunction<FlworTuple, Item> {
+    private final RuntimeIterator _expression;
 
-    public ReturnClauseDeserializeClosure() {
+    public OLD_ReturnFlatMapClosure(RuntimeIterator expression) {
+        this._expression = expression;
     }
 
-    /**
-     * @param row
-     * @return List<Item>iterator, deserialized from parametrized Row object containing the List<Item>
-     */
     @Override
-    public Iterator<Item> call(Row row) {
-        Object deserializedRow = ClosureUtils.deserializeRow(row);
-
-        return ((List<Item>) deserializedRow).iterator();
+    public Iterator<Item> call(FlworTuple v1) {
+        List<Item> result = new ArrayList<>();
+        _expression.open(new DynamicContext(v1));
+        while (_expression.hasNext())
+            result.add(_expression.next());
+        _expression.close();
+        return result.iterator();
     }
 }

--- a/src/main/java/sparksoniq/spark/closures/ReturnClauseDeserializeClosure.java
+++ b/src/main/java/sparksoniq/spark/closures/ReturnClauseDeserializeClosure.java
@@ -17,37 +17,28 @@
  * Author: Stefan Irimescu
  *
  */
- package sparksoniq.jsoniq.runtime.iterator;
+package sparksoniq.spark.closures;
 
-import org.apache.spark.api.java.JavaRDD;
-import sparksoniq.exceptions.SparkRuntimeException;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.sql.Row;
 import sparksoniq.jsoniq.item.Item;
-import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
-import sparksoniq.semantics.DynamicContext;
 
+import java.util.Iterator;
 import java.util.List;
 
-public abstract class LocalRuntimeIterator extends RuntimeIterator {
-    protected LocalRuntimeIterator(List<RuntimeIterator> children, IteratorMetadata iteratorMetadata) {
-        super(children, iteratorMetadata);
+public class ReturnClauseDeserializeClosure implements FlatMapFunction<Row, Item> {
+
+    public ReturnClauseDeserializeClosure() {
     }
 
+    /**
+     * @param row
+     * @return List<Item>iterator, deserialized from parametrized Row object containing the List<Item>
+     */
     @Override
-    public JavaRDD<Item> getRDD(DynamicContext dynamicContext)
-    {
-        throw new SparkRuntimeException("Iterator has no RDDs", getMetadata());
-    }
+    public Iterator<Item> call(Row row) {
+        Object deserializedRow = ClosureUtils.deserializeRow(row);
 
-    @Override
-    public boolean isRDD(){ return false; }
-
-    @Override
-    public boolean isDataFrame() {
-        return false;
-    }
-
-    @Override
-    public boolean getDataFrame() {
-        throw new SparkRuntimeException("Iterator has no DataFrames", getMetadata());
+        return ((List<Item>) deserializedRow).iterator();
     }
 }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/CountClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/CountClauseSparkIterator.java
@@ -36,6 +36,13 @@ public class CountClauseSparkIterator extends SparkRuntimeTupleIterator {
     }
 
     @Override
+    public boolean isDataFrame() {
+        // TODO implement letclause and remove the following return statement
+        return false;
+        //return _child.isDataFrame();
+    }
+
+    @Override
     public void open(DynamicContext context) {
         super.open(context);
 

--- a/src/main/java/sparksoniq/spark/iterator/flowr/CountClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/CountClauseSparkIterator.java
@@ -1,6 +1,8 @@
 package sparksoniq.spark.iterator.flowr;
 
 import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
 import sparksoniq.jsoniq.item.IntegerItem;
@@ -82,5 +84,10 @@ public class CountClauseSparkIterator extends SparkRuntimeTupleIterator {
         return _child.getRDD(context).zipWithIndex()
                 .mapValues(index -> index + 1)
                 .map(new CountClauseClosure(variableName, getMetadata()));
+    }
+
+    @Override
+    public Dataset<Row> getDataFrame(DynamicContext context) {
+        return null;
     }
 }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/ForClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/ForClauseSparkIterator.java
@@ -20,6 +20,11 @@
 package sparksoniq.spark.iterator.flowr;
 
 import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.jsoniq.item.Item;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
@@ -32,6 +37,7 @@ import sparksoniq.semantics.DynamicContext;
 import sparksoniq.spark.SparkSessionManager;
 import sparksoniq.spark.closures.ForClauseClosure;
 import sparksoniq.spark.closures.ForClauseLocalToRDDClosure;
+import sparksoniq.spark.closures.ForClauseSerializeClosure;
 import sparksoniq.spark.closures.InitialForClauseClosure;
 
 import java.util.ArrayList;
@@ -194,5 +200,61 @@ public class ForClauseSparkIterator extends SparkRuntimeTupleIterator {
             rdd = SparkSessionManager.getInstance().getJavaSparkContext().parallelize(contents);
         }
         return rdd;
+    }
+
+
+    @Override
+    public Dataset<Row> getDataFrame(DynamicContext context) {
+        this._df = null;
+
+        if (this._child == null) {
+            // create initial RDD from expression
+            JavaRDD<Item> initialRdd = this.getNewRDDFromExpression(_expression);
+
+            // TODO: define a schema
+            String schemaString = _variableName;
+            List<StructField> fields = new ArrayList<>();
+            for (String fieldName : schemaString.split(" ")) {
+                StructField field = DataTypes.createStructField(fieldName, DataTypes.BinaryType, true);
+                fields.add(field);
+            }
+            StructType schema = DataTypes.createStructType(fields);
+
+            // TODO: convert initial RDD to row RDD
+            JavaRDD<Row> rowRDD = initialRdd.map(new ForClauseSerializeClosure());
+
+            // TODO: apply the schema to row RDD
+            this._df = SparkSessionManager.getInstance().getOrCreateSession().createDataFrame(rowRDD, schema);
+
+        } else {        //if it's not a start clause
+            if (_child.isDataFrame()) {
+                this._df = this._child.getDataFrame(context);
+
+                // TODO: deserialize the byte array dataframe
+
+                // TODO: Update schema
+
+                // TODO: perform dataframe transformation
+
+                this._rdd = this._rdd.flatMap(new ForClauseClosure(_expression, _variableName));
+
+            } else {    // if child is locally evaluated
+                // _expression is definitely an RDD if execution flows here
+
+                _child.open(_currentDynamicContext);
+                _tupleContext = new DynamicContext(_currentDynamicContext);     // assign current context as parent
+                while (_child.hasNext()) {
+                    _inputTuple = _child.next();
+                    _tupleContext.removeAllVariables();             // clear the previous variables
+                    _tupleContext.setBindingsFromTuple(_inputTuple);      // assign new variables from new tuple
+
+                    JavaRDD<Item> expressionRDD = _expression.getRDD(_tupleContext);
+                    this._rdd = this._rdd.union(expressionRDD.map(new ForClauseLocalToRDDClosure(_variableName, _inputTuple)));
+                }
+                _child.close();
+            }
+        }
+        return _df;
+
     }
 }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/ForClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/ForClauseSparkIterator.java
@@ -39,7 +39,9 @@ import sparksoniq.spark.SparkSessionManager;
 import sparksoniq.spark.closures.*;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 public class ForClauseSparkIterator extends SparkRuntimeTupleIterator {
 
@@ -60,6 +62,12 @@ public class ForClauseSparkIterator extends SparkRuntimeTupleIterator {
     public boolean isRDD() {
         return (_expression.isRDD() || (_child != null && _child.isRDD()));
     }
+
+    @Override
+    public boolean isDataFrame() {
+        return (_expression.isRDD() || (_child != null && _child.isDataFrame()));
+    }
+
 
     @Override
     public void open(DynamicContext context) {
@@ -176,7 +184,7 @@ public class ForClauseSparkIterator extends SparkRuntimeTupleIterator {
                     _tupleContext.setBindingsFromTuple(_inputTuple);      // assign new variables from new tuple
 
                     JavaRDD<Item> expressionRDD = _expression.getRDD(_tupleContext);
-                    this._rdd = this._rdd.union(expressionRDD.map(new ForClauseLocalToRDDClosure(_variableName, _inputTuple)));
+                    this._rdd = this._rdd.union(expressionRDD.map(new OLD_ForClauseLocalToRDDClosure(_variableName, _inputTuple)));
                 }
                 _child.close();
             }
@@ -206,19 +214,14 @@ public class ForClauseSparkIterator extends SparkRuntimeTupleIterator {
         this._df = null;
 
         if (this._child == null) {
-            // create initial RDD from expression
-            JavaRDD<Item> initialRdd = this.getNewRDDFromExpression(_expression);
+            JavaRDD<Item> initialRdd = this.getNewRDDFromExpression(_expression, context);
 
             // define a schema
-            String schemaString = _variableName;
             List<StructField> fields = new ArrayList<>();
-            for (String fieldName : schemaString.split(" ")) {
-                StructField field = DataTypes.createStructField(fieldName, DataTypes.BinaryType, true);
-                fields.add(field);
-            }
+            StructField field = DataTypes.createStructField(_variableName, DataTypes.BinaryType, true);
+            fields.add(field);
             StructType schema = DataTypes.createStructType(fields);
 
-            // convert initial RDD to row RDD
             JavaRDD<Row> rowRDD = initialRdd.map(new ForClauseSerializeClosure());
 
             // apply the schema to row RDD
@@ -228,19 +231,13 @@ public class ForClauseSparkIterator extends SparkRuntimeTupleIterator {
             if (_child.isDataFrame()) {
                 this._df = this._child.getDataFrame(context);
 
-                // TODO: deserialize the byte array dataframe
-                // line below and related closure is currently very experimental
-                Dataset<Row> ds = this._df.map(new ForClauseDeserializeClosure(), Encoders.bean(Row.class));
+                // Add new column name to existing schema
+                String[] columnNamesPrimitive = this._df.schema().fieldNames();
+                ArrayList<String> columnNames = new ArrayList<>(Arrays.asList(columnNamesPrimitive));
+                columnNames.add(_variableName);
 
-                // TODO: Create new schema with the new for operation
-                StructType previousSchema = _df.schema();
-                String[] columnNames = previousSchema.fieldNames();
-
-
-
-                // TODO: perform dataframe transformation
-
-                this._rdd = this._rdd.flatMap(new ForClauseClosure(_expression, _variableName));
+                Dataset<Row> ds = this._df.flatMap(new ForClauseFlatMapClosure(_expression), Encoders.bean(Row.class));
+                this._df = ds.toDF(columnNames.toArray(new String[0]));
 
             } else {    // if child is locally evaluated
                 // _expression is definitely an RDD if execution flows here
@@ -252,13 +249,32 @@ public class ForClauseSparkIterator extends SparkRuntimeTupleIterator {
                     _tupleContext.removeAllVariables();             // clear the previous variables
                     _tupleContext.setBindingsFromTuple(_inputTuple);      // assign new variables from new tuple
 
+                    // Goal: Take every item and turn them into a row
                     JavaRDD<Item> expressionRDD = _expression.getRDD(_tupleContext);
-                    this._rdd = this._rdd.union(expressionRDD.map(new ForClauseLocalToRDDClosure(_variableName, _inputTuple)));
+
+                    // TODO - Optimization: Iterate schema creation only once
+                    Set<String> oldColumnNames = _inputTuple.getKeys();
+                    List<String> newColumnNames = new ArrayList<>();
+                    oldColumnNames.forEach(fieldName -> newColumnNames.add(fieldName));
+                    newColumnNames.add(_variableName);
+                    List<StructField> fields = new ArrayList<>();
+                    for (String columnName : newColumnNames) {
+                        StructField field = DataTypes.createStructField(columnName, DataTypes.BinaryType, true);
+                        fields.add(field);
+                    }
+                    StructType schema = DataTypes.createStructType(fields);
+
+                    JavaRDD<Row> rowRDD = expressionRDD.map(new ForClauseLocalToRowClosure(_inputTuple));
+
+                    if (this._df == null) {
+                        this._df = SparkSessionManager.getInstance().getOrCreateSession().createDataFrame(rowRDD, schema);
+                    } else {
+                        this._df = this._df.union(SparkSessionManager.getInstance().getOrCreateSession().createDataFrame(rowRDD, schema));
+                    }
                 }
                 _child.close();
             }
         }
         return _df;
-
     }
 }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/GroupByClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/GroupByClauseSparkIterator.java
@@ -21,6 +21,8 @@ package sparksoniq.spark.iterator.flowr;
 
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 import sparksoniq.exceptions.InvalidGroupVariableException;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.exceptions.NonAtomicKeyException;
@@ -202,5 +204,10 @@ public class GroupByClauseSparkIterator extends SparkRuntimeTupleIterator {
         //linearize iterable tuples into arrays
         this._rdd = groupedPair.map(new GroupByLinearizeTupleClosure(_variables));
         return _rdd;
+    }
+
+    @Override
+    public Dataset<Row> getDataFrame(DynamicContext context) {
+        return null;
     }
 }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/GroupByClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/GroupByClauseSparkIterator.java
@@ -60,6 +60,13 @@ public class GroupByClauseSparkIterator extends SparkRuntimeTupleIterator {
     }
 
     @Override
+    public boolean isDataFrame() {
+        // TODO implement letclause and remove the following return statement
+        return false;
+        // return _child.isDataFrame();
+    }
+
+    @Override
     public void open(DynamicContext context) {
         super.open(context);
 

--- a/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
@@ -20,6 +20,8 @@
  package sparksoniq.spark.iterator.flowr;
 
 import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
 import sparksoniq.jsoniq.item.Item;
@@ -158,6 +160,11 @@ public class LetClauseSparkIterator extends SparkRuntimeTupleIterator {
         if (_child != null) {
             _child.close();
         }
+    }
+
+    @Override
+    public Dataset<Row> getDataFrame(DynamicContext context) {
+        return null;
     }
 
 }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/LetClauseSparkIterator.java
@@ -61,6 +61,17 @@ public class LetClauseSparkIterator extends SparkRuntimeTupleIterator {
     }
 
     @Override
+    public boolean isDataFrame() {
+        // TODO implement letclause and remove the following return statement
+        return false;
+        /*if (this._child == null) {
+            return false;
+        } else {
+            return _child.isDataFrame();
+        }*/
+    }
+
+    @Override
     public FlworTuple next() {
         if(_hasNext == true){
             FlworTuple result = _nextLocalTupleResult;      // save the result to be returned

--- a/src/main/java/sparksoniq/spark/iterator/flowr/OrderByClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/OrderByClauseSparkIterator.java
@@ -62,6 +62,13 @@ public class OrderByClauseSparkIterator extends SparkRuntimeTupleIterator {
     }
 
     @Override
+    public boolean isDataFrame() {
+        // TODO implement letclause and remove the following return statement
+        return false;
+        // return _child.isDataFrame();
+    }
+
+    @Override
     public void open(DynamicContext context) {
         super.open(context);
 

--- a/src/main/java/sparksoniq/spark/iterator/flowr/OrderByClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/OrderByClauseSparkIterator.java
@@ -21,6 +21,8 @@ package sparksoniq.spark.iterator.flowr;
 
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.exceptions.NonAtomicKeyException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
@@ -174,5 +176,10 @@ public class OrderByClauseSparkIterator extends SparkRuntimeTupleIterator {
         keyTuplePair = keyTuplePair.sortByKey(new OrderByClauseSortClosure(this._expressions, _isStable));
         //map back to tuple RDD
         return keyTuplePair.map(tuple2 -> tuple2._2());
+    }
+
+    @Override
+    public Dataset<Row> getDataFrame(DynamicContext context) {
+        return null;
     }
 }

--- a/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
@@ -30,7 +30,7 @@ import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.jsoniq.runtime.tupleiterator.RuntimeTupleIterator;
 import sparksoniq.jsoniq.tuple.FlworTuple;
 import sparksoniq.semantics.DynamicContext;
-import sparksoniq.spark.closures.ReturnClauseDeserializeClosure;
+import sparksoniq.spark.closures.ReturnFlatMapClosure;
 
 import java.util.Arrays;
 
@@ -57,35 +57,9 @@ public class ReturnClauseSparkIterator extends HybridRuntimeIterator {
     public JavaRDD<Item> getRDD(DynamicContext context) {
         RuntimeIterator expression = this._children.get(0);
         Dataset<Row> df = this._child.getDataFrame(context);
-        JavaRDD<Item> rdd = df.javaRDD().flatMap(new ReturnClauseDeserializeClosure());
-
-
-        // TODO: apply return expression
-        // itemRDD = rdd.flatMap(new ReturnFlatMapClosure(expression));
+        JavaRDD<Item> rdd = df.javaRDD().flatMap(new ReturnFlatMapClosure(expression));
         return rdd;
     }
-    /*
-    public JavaRDD<Item> getDataFrame(DynamicContext context) {
-        RuntimeIterator expression = this._children.get(0);
-        Dataset<Row> df = this._child.getDataFrame(context);
-        JavaRDD<Item> rdd = df.javaRDD().flatMap((FlatMapFunction<Row, Item>) row -> {
-            Input input = new Input(new ByteArrayInputStream((byte[])row.get(0)));
-
-            Kryo kryo = new Kryo();
-            kryo.register(ArrayList.class);
-            kryo.register(Item.class);
-
-            List<Item> seqOfItems = kryo.readObject(input, ArrayList.class);
-            input.close();
-
-            return seqOfItems.iterator();
-        });
-
-        // TODO: apply return expression
-        // itemRDD = rdd.flatMap(new ReturnFlatMapClosure(expression));
-        return itemRDD;
-    }
-    */
 
     @Override
     protected boolean hasNextLocal() {

--- a/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/ReturnClauseSparkIterator.java
@@ -30,6 +30,7 @@ import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.jsoniq.runtime.tupleiterator.RuntimeTupleIterator;
 import sparksoniq.jsoniq.tuple.FlworTuple;
 import sparksoniq.semantics.DynamicContext;
+import sparksoniq.spark.closures.OLD_ReturnFlatMapClosure;
 import sparksoniq.spark.closures.ReturnFlatMapClosure;
 
 import java.util.Arrays;
@@ -56,9 +57,11 @@ public class ReturnClauseSparkIterator extends HybridRuntimeIterator {
     @Override
     public JavaRDD<Item> getRDD(DynamicContext context) {
         RuntimeIterator expression = this._children.get(0);
-        Dataset<Row> df = this._child.getDataFrame(context);
-        JavaRDD<Item> rdd = df.javaRDD().flatMap(new ReturnFlatMapClosure(expression));
-        return rdd;
+        if (_child.isDataFrame()) {
+            Dataset<Row> df = this._child.getDataFrame(context);
+            return df.javaRDD().flatMap(new ReturnFlatMapClosure(expression));
+        }
+        return this._child.getRDD(context).flatMap(new OLD_ReturnFlatMapClosure(expression));
     }
 
     @Override

--- a/src/main/java/sparksoniq/spark/iterator/flowr/WhereClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/WhereClauseSparkIterator.java
@@ -50,6 +50,13 @@ public class WhereClauseSparkIterator extends SparkRuntimeTupleIterator {
     }
 
     @Override
+    public boolean isDataFrame() {
+        // TODO implement letclause and remove the following return statement
+        return false;
+        // return _child.isDataFrame();
+    }
+
+    @Override
     public void open(DynamicContext context) {
         super.open(context);
 

--- a/src/main/java/sparksoniq/spark/iterator/flowr/WhereClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/WhereClauseSparkIterator.java
@@ -20,6 +20,8 @@
  package sparksoniq.spark.iterator.flowr;
 
 import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.exceptions.SparksoniqRuntimeException;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
@@ -107,5 +109,10 @@ public class WhereClauseSparkIterator extends SparkRuntimeTupleIterator {
             throw new SparksoniqRuntimeException("Invalid where clause.");
         }
         return _rdd;
+    }
+
+    @Override
+    public Dataset<Row> getDataFrame(DynamicContext context) {
+        return null;
     }
 }


### PR DESCRIPTION
Kryo version updated to 5.0.0-RC2

Default constructors added to Item classes to support Kryo serialization.

KryoManager added to efficiently stored Kryo Object
- Kryo doesn't support multithreaded operation by default.
- Version 5.0.0-RC2 adds multithreading support by Pool implementation ( https://github.com/EsotericSoftware/kryo#thread-safety)
- Kryo object is managed by a KryoPool.
- Pool implementation is also implemented for Input/Output objects, however this caused nondeterministic bugs. The code artifacts remain in the manager, however local creation of Input/Output objects seems to be functional at the moment.

getDataFrame is partially implemented in "For" and "return" clauses.
- Serialization/deserialization pipeline works and correctly returns the given input for the example below
```
for $i in parallelize(("test",null,3.5)) 
return $i
```

- No expression evaluation is currently implemented (returns the same input as above w/o object creation). I might need some input on how we are going to tackle the expressions. 
```
for $i in parallelize(("test",null,3.5)) 
return {"i": $i }
```

getDataFrame placeholder functions have been placed in all the other clauses.

Lastly, I have started experimenting with non-initial for clauses. I imagine the process will be:
* Deserialize the data
    * Row object contains columns of byte[]. A byte [] can be deserialized to Object and cast to List<Item> (original data type). Each column can be processed individually and this would yield a List\<List\<Item\>\> for a single row.  A row can potentially be recreated from the list of deserialized columns but at this point, I was worried that I was getting side-tracked and losing the advantages of having Dataframes through too much manual manipulation.
* Apply expression
    * In the RDD structure, we would add Flwortuples to Dynamic context and evaluate the expressions. How are we going to evaluate the expressions in the Dataframe structure? Somehow map them into sql-like expressions? In that case we need to recreate the dataframe with the deserialized data in the previous section* Apply expression.
* Create new schema
* Form the new dataframe 



