### PR TITLE
Improve code organization and styling for testing

### DIFF
--- a/src/main/java/sparksoniq/JsoniqQueryExecutor.java
+++ b/src/main/java/sparksoniq/JsoniqQueryExecutor.java
@@ -188,8 +188,8 @@ public class JsoniqQueryExecutor {
         try {
             // TODO Handle module extras
             JsoniqParser.ModuleContext module = parser.module();
-            JsoniqParser.MainModuleContext unit = module.main;
-            visitor.visit(unit);
+            JsoniqParser.MainModuleContext main = module.main;
+            visitor.visit(main);
         } catch (ParseCancellationException ex) {
             ParsingException e = new ParsingException(lexer.getText(), new ExpressionMetadata(lexer.getLine(),
                     lexer.getCharPositionInLine()));

--- a/src/main/java/sparksoniq/spark/SparkSessionManager.java
+++ b/src/main/java/sparksoniq/spark/SparkSessionManager.java
@@ -50,7 +50,7 @@ public class SparkSessionManager {
         return session;
     }
 
-    private void setDefaultConfiguration () {
+    private void setDefaultConfiguration() {
         configuration = new SparkConf().setAppName(APP_NAME);
     }
 
@@ -60,11 +60,10 @@ public class SparkSessionManager {
             Logger.getLogger("org").setLevel(LOG_LEVEL);
             Logger.getLogger("akka").setLevel(LOG_LEVEL);
 
-            session= SparkSession.builder().config(this.configuration).getOrCreate();
+            session = SparkSession.builder().config(this.configuration).getOrCreate();
         } else {
             throw new SparksoniqRuntimeException("Session already exists: new session initialization prevented.");
         }
-
     }
 
     private void initializeKryoSerialization() {
@@ -85,10 +84,10 @@ public class SparkSessionManager {
     public void initializeConfigurationAndSession(SparkConf conf, boolean setAppName) {
         if (setAppName)
             conf.setAppName(APP_NAME);
-        configuration = conf;
+        this.configuration = conf;
+        initializeKryoSerialization();
         initialize();
     }
-
 
     public JavaSparkContext getJavaSparkContext() {
         if (javaSparkContext == null) {
@@ -96,5 +95,4 @@ public class SparkSessionManager {
         }
         return javaSparkContext;
     }
-
 }

--- a/src/main/resources/test_files/runtime/JsoniqVersion.iq
+++ b/src/main/resources/test_files/runtime/JsoniqVersion.iq
@@ -1,4 +1,4 @@
-(:JIQS: ShouldNotParse; ErrorCode="XQST0031" :)
+(:JIQS: ShouldRun; Output="2" :)
 jsoniq version "2.0" ;
 
 1+1

--- a/src/test/java/iq/RuntimeTests.java
+++ b/src/test/java/iq/RuntimeTests.java
@@ -71,11 +71,16 @@ public class RuntimeTests extends AnnotationsTestsBase {
     public static void setupSparkSession() {
         SparkConf sparkConfiguration = new SparkConf();
         sparkConfiguration.setMaster("local[*]");
+        sparkConfiguration.set("spark.submit.deployMode", "client");
+        sparkConfiguration.set("spark.executor.extraClassPath", "lib/");
+        sparkConfiguration.set("spark.driver.extraClassPath", "lib/");
+
         // sparkConfiguration.set("spark.driver.memory", "2g");
         // sparkConfiguration.set("spark.executor.memory",   "2g");
-        sparkConfiguration.set("spark.speculation", "true");
-        sparkConfiguration.set("spark.speculation.quantile", "0.5");
+        // sparkConfiguration.set("spark.speculation", "true");
+        // sparkConfiguration.set("spark.speculation.quantile", "0.5");
         SparkSessionManager.getInstance().initializeConfigurationAndSession(sparkConfiguration, true);
+
     }
 
     public RuntimeTests(File testFile) {

--- a/src/test/java/iq/SparkRuntimeTests.java
+++ b/src/test/java/iq/SparkRuntimeTests.java
@@ -51,10 +51,8 @@ public class SparkRuntimeTests extends RuntimeTests {
     @Override
     protected void checkExpectedOutput(String expectedOutput, RuntimeIterator runtimeIterator) {
         String actualOutput = runIterators(runtimeIterator);
-        Assert.assertTrue("Expected output: " + expectedOutput + " Actual result: "
-                        + actualOutput,
+        Assert.assertTrue("Expected output: " + expectedOutput + " Actual result: " + actualOutput,
                 expectedOutput.equals(actualOutput));
-                //unorderedItemSequenceStringsAreEqual(expectedOutput, actualOutput));
+        // unorderedItemSequenceStringsAreEqual(expectedOutput, actualOutput));
     }
-
 }

--- a/src/test/java/iq/base/AnnotationsTestsBase.java
+++ b/src/test/java/iq/base/AnnotationsTestsBase.java
@@ -73,15 +73,15 @@ public class AnnotationsTestsBase {
         try {
             context = this.parse(new FileReader(path), visitor);
 
-            //generate static context and runtime iterators
+            // generate static context and runtime iterators
             if (visitor instanceof JsoniqExpressionTreeVisitor) {
                 JsoniqExpressionTreeVisitor completeVisitor = ((JsoniqExpressionTreeVisitor) visitor);
-                //generate static context
+                // generate static context
                 new StaticContextVisitor().visit(completeVisitor.getQueryExpression(), completeVisitor.getQueryExpression().getStaticContext());
-                //generate iterators
+                // generate iterators
                 runtimeIterator = new RuntimeIteratorVisitor().visit(completeVisitor.getQueryExpression(), null);
             }
-            //PARSING
+            // PARSING
         } catch (ParsingException exception) {
             String errorOutput = exception.getMessage();
             checkErrorCode(errorOutput, currentAnnotation.getErrorCode(), currentAnnotation.getErrorMetadata());
@@ -94,7 +94,7 @@ public class AnnotationsTestsBase {
                 return context;
             }
 
-            //SEMANTIC
+            // SEMANTIC
         } catch (SemanticException exception) {
             String errorOutput = exception.getMessage();
             checkErrorCode(errorOutput, currentAnnotation.getErrorCode(), currentAnnotation.getErrorMetadata());
@@ -110,7 +110,7 @@ public class AnnotationsTestsBase {
             } catch (Exception ex) {
             }
 
-            //RUNTIME
+            // RUNTIME
         } catch (SparksoniqRuntimeException exception) {
             String errorOutput = exception.getMessage();
             checkErrorCode(errorOutput, currentAnnotation.getErrorCode(), currentAnnotation.getErrorMetadata());
@@ -125,7 +125,6 @@ public class AnnotationsTestsBase {
                 }
             } catch (Exception ex) {
             }
-
         }
 
         try {
@@ -141,7 +140,7 @@ public class AnnotationsTestsBase {
             return context;
         }
 
-        //PROGRAM SHOULD RUN
+        // PROGRAM SHOULD RUN
         if (currentAnnotation instanceof AnnotationProcessor.RunnableTestAnnotation &&
                 currentAnnotation.shouldRun()) {
             try {
@@ -165,21 +164,7 @@ public class AnnotationsTestsBase {
                 Assert.fail("Program executed when not expected to");
             }
         }
-
         return context;
-    }
-
-    protected void checkErrorCode(String errorOutput, String expectedErrorCode, String errorMetadata) {
-        if (errorOutput != null && expectedErrorCode != null)
-            Assert.assertTrue("Unexpected error code returned; Expected: " + expectedErrorCode +
-                    "; Error: " + errorOutput, errorOutput.contains(expectedErrorCode));
-        if (errorOutput != null && errorMetadata != null)
-            Assert.assertTrue("Unexpected metadata returned; Expected: " + errorMetadata +
-                    "; Error: " + errorOutput, errorOutput.contains(errorMetadata));
-    }
-
-    protected void checkExpectedOutput(String expectedOutput, RuntimeIterator runtimeIterator) {
-        Assert.assertTrue(true);
     }
 
     private JsoniqParser.MainModuleContext parse(FileReader reader, JsoniqBaseVisitor visitor) throws IOException {
@@ -199,8 +184,18 @@ public class AnnotationsTestsBase {
             e.initCause(ex);
             throw e;
         }
-
     }
 
+    protected void checkExpectedOutput(String expectedOutput, RuntimeIterator runtimeIterator) {
+        Assert.assertTrue(true);
+    }
 
+    protected void checkErrorCode(String errorOutput, String expectedErrorCode, String errorMetadata) {
+        if (errorOutput != null && expectedErrorCode != null)
+            Assert.assertTrue("Unexpected error code returned; Expected: " + expectedErrorCode +
+                    "; Error: " + errorOutput, errorOutput.contains(expectedErrorCode));
+        if (errorOutput != null && errorMetadata != null)
+            Assert.assertTrue("Unexpected metadata returned; Expected: " + errorMetadata +
+                    "; Error: " + errorOutput, errorOutput.contains(errorMetadata));
+    }
 }

--- a/src/test/java/iq/base/AnnotationsTestsBase.java
+++ b/src/test/java/iq/base/AnnotationsTestsBase.java
@@ -173,9 +173,15 @@ public class AnnotationsTestsBase {
         parser.setErrorHandler(new BailErrorStrategy());
 
         try {
-            JsoniqParser.ModuleContext unit = parser.module();
+            // the original
+            /*JsoniqParser.ModuleContext unit = parser.module();
             JsoniqParser.MainModuleContext main = unit.main;
-            visitor.visit(unit);
+            visitor.visit(unit);*/
+
+            JsoniqParser.ModuleContext module = parser.module();
+            JsoniqParser.MainModuleContext main = module.main;
+            visitor.visit(main);
+
             return main;
 
         } catch (ParseCancellationException ex) {


### PR DESCRIPTION
While trying to fix a bug with dataframe testing, I have re-organized the code and comments in testing and jsoniq queryExecutor. I believe these changes can be applied to master. 

The only two functional changes are the following:
1-) Spark configuration of the testing suite has been updated to match the current/common parameters (In RuntimeTests.java line 74)
2-) Parse function used in testing have been made identical to the visitor call in JsoniqQueryExecutor. (In AnnotationTestBase.java line 181). 

The second change resulted in me updating the test JsoniqVersion.iq. Previously, this test has been regarded as ShoulNotParse. However sparksoniq seems to be able to parse it and produce the output "2", which is identical behavior to Zorba. Is this behavior correct/is there something that I'm missing?

Edit: I wanted to elaborate on the mentioned bug. Some test case queries worked fine in the shell application however, the same queries were failing in the testing suite with a java.lang.AbstractMethodError thrown by spark.internal.Logging. While trying to figure out the cause, I made the changes to make shell and test-suite identical (moving code around was a byproduct)

Fortunately, I found the hint that this is a versioning problem at the following link: https://stackoverflow.com/questions/52993141/java-lang-abstractmethoderror-org-apache-spark-internal-loggingclass-initializ
Synchronizing the spark and sparksql versions fixed the issue. 
