### PR TITLE
Fix bug to make sure the local query is read from the file provided w…

### DIFF
--- a/src/main/java/sparksoniq/JsoniqQueryExecutor.java
+++ b/src/main/java/sparksoniq/JsoniqQueryExecutor.java
@@ -69,9 +69,10 @@ public class JsoniqQueryExecutor {
         SparkSessionManager.COLLECT_ITEM_LIMIT = itemLimit;
     }
 
-    public String runLocal() throws IOException {
+    public String runLocal(String queryFile) throws IOException {
+        FileInputStream fis = new FileInputStream(queryFile);
         JsoniqExpressionTreeVisitor visitor = this.parse(new JsoniqLexer(
-                new ANTLRInputStream(Main.class.getResourceAsStream("/queries/runQuery.iq"))));
+                new ANTLRInputStream(fis)));
         // generate static context
         generateStaticContext(visitor.getQueryExpression());
         // generate iterators

--- a/src/main/java/sparksoniq/Main.java
+++ b/src/main/java/sparksoniq/Main.java
@@ -73,7 +73,6 @@ public class Main {
             translator = new JsoniqQueryExecutor(local, 200, logFilePath);
         if (local) {
             String result = translator.runLocal(queryFile);
-            System.out.println(result);
             List<String> lines = Arrays.asList(result);
             Path file = Paths.get(outputDataFilePath);
             Files.write(file, lines, Charset.forName("UTF-8"));

--- a/src/main/java/sparksoniq/Main.java
+++ b/src/main/java/sparksoniq/Main.java
@@ -72,7 +72,8 @@ public class Main {
         else
             translator = new JsoniqQueryExecutor(local, 200, logFilePath);
         if (local) {
-            String result = translator.runLocal();
+            String result = translator.runLocal(queryFile);
+            System.out.println(result);
             List<String> lines = Arrays.asList(result);
             Path file = Paths.get(outputDataFilePath);
             Files.write(file, lines, Charset.forName("UTF-8"));


### PR DESCRIPTION
Fix bug to make sure the local query is read from the file provided with --query-path.

Right now, --query-path is ignored and instead an arbitrary query file is being taken from internal resources.

With the fix, this can be used for local measurements:

    spark-submit  --master local[*]
                  target/jsoniq-spark-app-0.9.5-jar-with-dependencies.jar
                  --output-path /tmp/output.txt --query-path /tmp/query.jq