### PR TITLE
Add text-file#1 and text-file#2 functions to parse raw text into stri…

### DIFF
--- a/src/main/java/sparksoniq/io/json/StringMapper.java
+++ b/src/main/java/sparksoniq/io/json/StringMapper.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Stefan Irimescu
+ *
+ */
+package sparksoniq.io.json;
+
+import org.apache.spark.api.java.function.FlatMapFunction;
+import sparksoniq.jsoniq.item.Item;
+import sparksoniq.jsoniq.item.StringItem;
+
+import java.util.Iterator;
+
+public class StringMapper implements FlatMapFunction<Iterator<String>, Item> {
+
+    public StringMapper() {
+    }
+
+    @Override
+    public Iterator<Item> call(Iterator<String> stringIterator) throws Exception {
+        return new Iterator<Item>() {
+            @Override
+            public boolean hasNext() {
+                return stringIterator.hasNext();
+            }
+            @Override
+            public Item next() {
+                Item stringItem = new StringItem(stringIterator.next());
+                return stringItem;
+            }
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+}

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/base/Functions.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/base/Functions.java
@@ -46,6 +46,7 @@ import sparksoniq.jsoniq.runtime.iterator.functions.strings.SubstringFunctionIte
 import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
 import sparksoniq.spark.iterator.function.ParallelizeFunctionIterator;
 import sparksoniq.spark.iterator.function.ParseJsonFunctionIterator;
+import sparksoniq.spark.iterator.function.ParseTextFunctionIterator;
 
 import java.util.HashMap;
 import java.util.List;
@@ -59,6 +60,8 @@ public class Functions {
         buildInFunctions = new HashMap<>();
         buildInFunctions.put(new SparksoniqFunctionSignature(JSON_FILE, 1), ParseJsonFunctionIterator.class);
         buildInFunctions.put(new SparksoniqFunctionSignature(JSON_FILE, 2), ParseJsonFunctionIterator.class);
+        buildInFunctions.put(new SparksoniqFunctionSignature(TEXT_FILE, 1), ParseTextFunctionIterator.class);
+        buildInFunctions.put(new SparksoniqFunctionSignature(TEXT_FILE, 2), ParseTextFunctionIterator.class);
         buildInFunctions.put(new SparksoniqFunctionSignature(PARALLELIZE, 1), ParallelizeFunctionIterator.class);
         buildInFunctions.put(new SparksoniqFunctionSignature(COUNT, 1), CountFunctionIterator.class);
 
@@ -147,9 +150,13 @@ public class Functions {
     public static class FunctionNames {
 
         /**
-         * function that parses a text file
+         * function that parses a JSON lines file
          */
         public static final String JSON_FILE = "json-file";
+        /**
+         * function that parses a text file
+         */
+        public static final String TEXT_FILE = "text-file";
         /**
          * function that parallelizes item collections into a Spark RDD
          */

--- a/src/main/java/sparksoniq/spark/iterator/function/ParseTextFunctionIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/function/ParseTextFunctionIterator.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Stefan Irimescu
+ *
+ */
+package sparksoniq.spark.iterator.function;
+
+import org.apache.spark.api.java.JavaRDD;
+
+import sparksoniq.io.json.StringMapper;
+import sparksoniq.jsoniq.item.Item;
+import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
+import sparksoniq.jsoniq.runtime.metadata.IteratorMetadata;
+import sparksoniq.semantics.DynamicContext;
+import sparksoniq.spark.SparkSessionManager;
+
+import javax.naming.OperationNotSupportedException;
+import java.util.List;
+
+public class ParseTextFunctionIterator extends SparkFunctionCallIterator {
+    public ParseTextFunctionIterator(List<RuntimeIterator> arguments, IteratorMetadata iteratorMetadata) {
+        super(arguments, iteratorMetadata);
+    }
+
+    @Override
+    public void open(DynamicContext context) {
+        super.open(context);
+
+        long resultSize = this.getRDD(_currentDynamicContext).count();
+        if (resultSize == 0) {
+            this._hasNext = false;
+        } else {
+            this._hasNext = true;
+        }
+    }
+
+    @Override
+    public JavaRDD<Item> getRDD(DynamicContext context) {
+        if (this._rdd == null) {
+            JavaRDD<String> strings;
+            RuntimeIterator urlIterator = this._children.get(0);
+            urlIterator.open(context);
+            if (this._children.size() == 1)
+                try {
+                    strings = SparkSessionManager.getInstance().getJavaSparkContext().textFile(urlIterator.next().getStringValue());
+                } catch (OperationNotSupportedException e) {
+                    throw new IllegalArgumentException("parse-json illegal argument");
+                }
+            else {
+                RuntimeIterator partitionsIterator = this._children.get(1);
+                partitionsIterator.open(_currentDynamicContext);
+                try {
+                    strings = SparkSessionManager.getInstance().getJavaSparkContext().textFile(
+                            urlIterator.next().getStringValue(),
+                            partitionsIterator.next().getIntegerValue());
+                } catch (OperationNotSupportedException e) {
+                    throw new IllegalArgumentException("parse-json illegal argument");
+                }
+                partitionsIterator.close();
+            }
+
+            _rdd = strings.mapPartitions(new StringMapper());
+            urlIterator.close();
+        }
+        return _rdd;
+    }
+
+}

--- a/src/main/resources/queries/file.txt
+++ b/src/main/resources/queries/file.txt
@@ -1,0 +1,3 @@
+foo
+bar
+foobar

--- a/src/main/resources/test_files/runtime-spark/TextFile.jq
+++ b/src/main/resources/test_files/runtime-spark/TextFile.jq
@@ -1,0 +1,2 @@
+(:JIQS: ShouldRun; Output="(foo, bar, foobar)" :)
+json-file("./src/main/resources/queries/file.txt", 10)

--- a/src/main/resources/test_files/runtime-spark/TextFile2.jq
+++ b/src/main/resources/test_files/runtime-spark/TextFile2.jq
@@ -1,0 +1,2 @@
+(:JIQS: ShouldRun; Output="(foo, bar, foobar)" :)
+json-file("./src/main/resources/queries/file.txt")


### PR DESCRIPTION
Text files can now be parsed in JSONiq, resulting into collections of string items.

(More string functions to come, e.g., tokenize()).

Solves https://github.com/Sparksoniq/sparksoniq/issues/118

Most of the code is directly taken over from parse-json, and adapted with minimum changes.