### PR TITLE
Fix idiv result.

### DIFF
--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/MultiplicativeOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/MultiplicativeOperationIterator.java
@@ -115,7 +115,7 @@ public class MultiplicativeOperationIterator extends BinaryOperationBaseIterator
                     case MOD:
                         return new DoubleItem(l % r);
                     case IDIV:
-                        return new DoubleItem((int) (l / r));
+                        return new IntegerItem((int) (l / r));
                     default:
                         new IteratorFlowException("Non recognized multicative operator.", getMetadata());
                 }
@@ -130,7 +130,7 @@ public class MultiplicativeOperationIterator extends BinaryOperationBaseIterator
                     case MOD:
                         return new DecimalItem(l.remainder(r));
                     case IDIV:
-                        return new DecimalItem(l.divideToIntegralValue(r));
+                        return new IntegerItem(l.divideToIntegralValue(r).intValueExact());
                     default:
                         new IteratorFlowException("Non recognized multicative operator.", getMetadata());
                 }

--- a/src/main/resources/test_files/runtime/Operational/MultiplicativeOp4.iq
+++ b/src/main/resources/test_files/runtime/Operational/MultiplicativeOp4.iq
@@ -1,4 +1,4 @@
-(:JIQS: ShouldRun; Output="(2, 2, 2.0, 2, 2.0, 2.0, 2)" :)
+(:JIQS: ShouldRun; Output="(2, 2, 2, 2, 2, 2, 2)" :)
 4 idiv 2,
 4 idiv 2.0,
 4 idiv 2e0,


### PR DESCRIPTION
idiv must always return an integer. Fixes https://github.com/Sparksoniq/sparksoniq/issues/74

https://www.w3.org/TR/xpath-functions-31/#func-numeric-integer-divide