### PR TITLE
Simplification of Item API

### DIFF
--- a/src/main/java/sparksoniq/jsoniq/item/ArrayItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/ArrayItem.java
@@ -25,8 +25,6 @@ import com.esotericsoftware.kryo.io.Output;
 import sparksoniq.semantics.types.ItemType;
 import sparksoniq.semantics.types.ItemTypes;
 
-import javax.naming.OperationNotSupportedException;
-
 import org.apache.commons.lang3.StringEscapeUtils;
 
 import java.util.ArrayList;
@@ -50,28 +48,7 @@ public class ArrayItem extends JsonItem {
     }
 
     @Override
-    public Item getItemByKey(String s) throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Array items are not objects");
-    }
-
-    @Override
     public void putItem(Item value) { this._arrayItems.add(value); }
-
-    @Override
-    public void putItemByKey(String s, Item value) throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Array items are not objects");
-    }
-
-    @Override
-    public List<String> getKeys() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Array items are not objects");
-    }
-
-    @Override
-    public Collection<? extends Item> getValues() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Array items are not objects");
-    }
-
 
     @Override
     public  boolean isArray(){ return true; }

--- a/src/main/java/sparksoniq/jsoniq/item/ArrayItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/ArrayItem.java
@@ -69,7 +69,7 @@ public class ArrayItem extends JsonItem {
         StringBuilder sb = new StringBuilder();
         sb.append("[ ");
         for (Item item : this._arrayItems) {
-            boolean isStringValue = item instanceof StringItem;
+            boolean isStringValue = item.isString();
             if(isStringValue) {
                 sb.append("\"");
                 sb.append(StringEscapeUtils.escapeJson(item.serialize()));

--- a/src/main/java/sparksoniq/jsoniq/item/AtomicItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/AtomicItem.java
@@ -22,7 +22,6 @@
 import sparksoniq.semantics.types.ItemType;
 import sparksoniq.semantics.types.ItemTypes;
 
-import javax.naming.OperationNotSupportedException;
 import java.util.Collection;
 import java.util.List;
 
@@ -31,46 +30,6 @@ public abstract class AtomicItem extends Item {
     public boolean isAtomic()
     {
         return true;
-    }
-
-    @Override
-    public List<Item> getItems() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Atomic items are not arrays");
-    }
-
-    @Override
-    public Item getItemAt(int i) throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Atomic items are not arrays");
-    }
-
-    @Override
-    public void putItem(Item value) throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Atomic items are not arrays");
-    }
-
-    @Override
-    public Item getItemByKey(String s) throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Atomic items are not objects");
-    }
-
-    @Override
-    public void putItemByKey(String s, Item value) throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Atomic items are not objects");
-    }
-
-    @Override
-    public List<String> getKeys() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Atomic items are not objects");
-    }
-
-    @Override
-    public Collection<? extends Item> getValues() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Atomic items are not objects");
-    }
-
-    @Override
-    public int getSize() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Atomic items are not arrays");
     }
 
     @Override public boolean isTypeOf(ItemType type) {

--- a/src/main/java/sparksoniq/jsoniq/item/BooleanItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/BooleanItem.java
@@ -40,28 +40,8 @@ public class BooleanItem extends AtomicItem {
     }
 
     @Override
-    public String getStringValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Boolean value exception");
-    }
-
-    @Override
     public boolean getBooleanValue() {
         return _value;
-    }
-
-    @Override
-    public double getDoubleValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Boolean value exception");
-    }
-
-    @Override
-    public int getIntegerValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Boolean value exception");
-    }
-
-    @Override
-    public BigDecimal getDecimalValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Boolean value exception");
     }
 
     @Override

--- a/src/main/java/sparksoniq/jsoniq/item/DecimalItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/DecimalItem.java
@@ -41,26 +41,6 @@ public class DecimalItem extends AtomicItem {
     }
 
     @Override
-    public String getStringValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Decimal value exception");
-    }
-
-    @Override
-    public boolean getBooleanValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Decimal value exception");
-    }
-
-    @Override
-    public double getDoubleValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Decimal value exception");
-    }
-
-    @Override
-    public int getIntegerValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Decimal value exception");
-    }
-
-    @Override
     public BigDecimal getDecimalValue() {
         return _value;
     }

--- a/src/main/java/sparksoniq/jsoniq/item/DoubleItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/DoubleItem.java
@@ -40,28 +40,8 @@ public class DoubleItem extends AtomicItem {
     }
 
     @Override
-    public String getStringValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Double value exception");
-    }
-
-    @Override
-    public boolean getBooleanValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Double value exception");
-    }
-
-    @Override
     public double getDoubleValue() {
         return _value;
-    }
-
-    @Override
-    public int getIntegerValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Double value exception");
-    }
-
-    @Override
-    public BigDecimal getDecimalValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Double value exception");
     }
 
     @Override

--- a/src/main/java/sparksoniq/jsoniq/item/IntegerItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/IntegerItem.java
@@ -40,28 +40,8 @@ public class IntegerItem extends AtomicItem {
     }
 
     @Override
-    public String getStringValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Integer value exception");
-    }
-
-    @Override
-    public boolean getBooleanValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Integer value exception");
-    }
-
-    @Override
-    public double getDoubleValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Integer value exception");
-    }
-
-    @Override
     public int getIntegerValue()  {
         return _value;
-    }
-
-    @Override
-    public BigDecimal getDecimalValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Integer value exception");
     }
 
     @Override

--- a/src/main/java/sparksoniq/jsoniq/item/Item.java
+++ b/src/main/java/sparksoniq/jsoniq/item/Item.java
@@ -160,7 +160,7 @@ public abstract class Item implements SerializableItem {
     }
 
     public List<Item> getItems() {
-        throw new RuntimeException("Item is not an array or object.");
+        throw new RuntimeException("Item is not an array.");
     };
 
     public Item getItemAt(int i) {
@@ -176,7 +176,7 @@ public abstract class Item implements SerializableItem {
     };
 
     public Collection<? extends Item> getValues() {
-        throw new RuntimeException("Item is not an array or object.");
+        throw new RuntimeException("Item is not an object.");
     };
 
     public Item getItemByKey(String s) {
@@ -192,7 +192,7 @@ public abstract class Item implements SerializableItem {
     };
 
     public String getStringValue() {
-        throw new RuntimeException("getStringValue: Item is not a string.");
+        throw new RuntimeException("Item is not a string.");
     };
 
     public boolean getBooleanValue() {

--- a/src/main/java/sparksoniq/jsoniq/item/Item.java
+++ b/src/main/java/sparksoniq/jsoniq/item/Item.java
@@ -163,31 +163,57 @@ public abstract class Item implements SerializableItem {
         return compareItems(v1, v2) == 0;
     }
 
-    public abstract List<Item> getItems() throws OperationNotSupportedException;
+    public List<Item> getItems() {
+        throw new RuntimeException("Item is not an array or object.");
+    };
 
-    public abstract Item getItemAt(int i) throws OperationNotSupportedException;
+    public Item getItemAt(int i) {
+        throw new RuntimeException("Item is not an array.");
+    };
 
-    public abstract void putItem(Item value) throws OperationNotSupportedException;
+    public void putItem(Item value) {
+        throw new RuntimeException("Item is not an array.");
+    };
 
-    public abstract List<String> getKeys() throws OperationNotSupportedException;
+    public List<String> getKeys() {
+        throw new RuntimeException("Item is not an object.");
+    };
 
-    public abstract Collection<? extends Item> getValues() throws OperationNotSupportedException;
+    public Collection<? extends Item> getValues() {
+        throw new RuntimeException("Item is not an array or object.");
+    };
 
-    public abstract Item getItemByKey(String s) throws OperationNotSupportedException;
+    public Item getItemByKey(String s) {
+        throw new RuntimeException("Item is not an object.");
+    };
 
-    public abstract void putItemByKey(String s, Item value) throws OperationNotSupportedException;
+    public void putItemByKey(String s, Item value) {
+        throw new RuntimeException("Item is not an object.");
+    };
 
-    public abstract int getSize() throws OperationNotSupportedException;
+    public int getSize() {
+        throw new RuntimeException("Item is not an array.");
+    };
 
-    public abstract String getStringValue() throws OperationNotSupportedException;
+    public String getStringValue() {
+        throw new RuntimeException("Item is not a string.");
+    };
 
-    public abstract boolean getBooleanValue() throws OperationNotSupportedException;
+    public boolean getBooleanValue() {
+        throw new RuntimeException("Item is not a boolean.");
+    };
 
-    public abstract double getDoubleValue() throws OperationNotSupportedException;
+    public double getDoubleValue() {
+        throw new RuntimeException("Item is not a double.");
+    };
 
-    public abstract int getIntegerValue() throws OperationNotSupportedException;
+    public int getIntegerValue() {
+        throw new RuntimeException("Item is not an integer.");
+    };
 
-    public abstract BigDecimal getDecimalValue() throws OperationNotSupportedException;
+    public BigDecimal getDecimalValue() {
+        throw new RuntimeException("Item is not a big decimal.");
+    };
 
     public abstract boolean isTypeOf(ItemType type);
 

--- a/src/main/java/sparksoniq/jsoniq/item/Item.java
+++ b/src/main/java/sparksoniq/jsoniq/item/Item.java
@@ -34,12 +34,8 @@ import java.util.List;
 
 //TODO serialize with indentation
 public abstract class Item implements SerializableItem {
-    public static boolean isAtomic(Item resultItem) {
-        return resultItem instanceof AtomicItem;
-    }
-
     public static boolean isNumeric(Item item) {
-        return item instanceof IntegerItem || item instanceof DecimalItem || item instanceof DoubleItem;
+        return item.isInteger() || item.isDecimal() || item.isDouble();
     }
 
     //performs conversions for binary operations with a numeric return type
@@ -47,17 +43,17 @@ public abstract class Item implements SerializableItem {
     //(int,decimal) -> decimal
     //(decimal,double) -> double
     public static Type getNumericResultType(Item left, Item right) {
-        if (left instanceof DecimalItem)
+        if (left.isDecimal())
             return DecimalItem.class;
-        if (left instanceof DoubleItem) {
-            if (right instanceof DecimalItem)
+        if (left.isDouble()) {
+            if (right.isDecimal())
                 return DecimalItem.class;
             return DoubleItem.class;
         }
-        if (left instanceof IntegerItem) {
-            if (right instanceof DoubleItem)
+        if (left.isInteger()) {
+            if (right.isDouble())
                 return DoubleItem.class;
-            if (right instanceof DecimalItem)
+            if (right.isDecimal())
                 return DecimalItem.class;
             return IntegerItem.class;
         }
@@ -66,24 +62,24 @@ public abstract class Item implements SerializableItem {
 
     public static <T> T getNumericValue(Item item, Class<T> type) {
         if (isNumeric(item)) {
-            if (item instanceof DoubleItem) {
-                Double result = ((DoubleItem) item).getDoubleValue();
+            if (item.isDouble()) {
+                Double result = item.getDoubleValue();
                 if (type.equals(BigDecimal.class))
                     return (T) BigDecimal.valueOf(result);
                 if (type.equals(Integer.class))
                     return (T) new Integer(result.intValue());
                 return (T) result;
             }
-            if (item instanceof IntegerItem) {
-                Integer result = ((IntegerItem) item).getIntegerValue();
+            if (item.isInteger()) {
+                Integer result = item.getIntegerValue();
                 if (type.equals(BigDecimal.class))
                     return (T) BigDecimal.valueOf(result);
                 if (type.equals(Double.class))
                     return (T) new Double(result.doubleValue());
                 return (T) result;
             }
-            if (item instanceof DecimalItem) {
-                BigDecimal result = ((DecimalItem) item).getDecimalValue();
+            if (item.isDecimal()) {
+                BigDecimal result = item.getDecimalValue();
                 if (type.equals(Integer.class))
                     return (T) new Integer(result.intValue());
                 if (type.equals(Double.class))
@@ -99,23 +95,23 @@ public abstract class Item implements SerializableItem {
     public static boolean getEffectiveBooleanValue(Item item) {
         if (item == null)
             return false;
-        else if (item instanceof BooleanItem)
-            return ((BooleanItem) item).getBooleanValue();
+        else if (item.isBoolean())
+            return item.getBooleanValue();
         else if (isNumeric(item)) {
-            if (item instanceof IntegerItem)
-                return ((IntegerItem) item).getIntegerValue() != 0;
-            else if (item instanceof DoubleItem)
-                return ((DoubleItem) item).getDoubleValue() != 0;
-            else if (item instanceof DecimalItem)
-                return !((DecimalItem) item).getDecimalValue().equals(0);
+            if (item.isInteger())
+                return item.getIntegerValue() != 0;
+            else if (item.isDouble())
+                return item.getDoubleValue() != 0;
+            else if (item.isDecimal())
+                return !item.getDecimalValue().equals(0);
         }
-        else if (item instanceof NullItem)
+        else if (item.isNull())
             return false;
-        else if (item instanceof StringItem)
-            return !((StringItem) item).getStringValue().isEmpty();
-        else if (item instanceof ObjectItem)
+        else if (item.isString())
+            return !item.getStringValue().isEmpty();
+        else if (item.isObject())
             return true;
-        else if (item instanceof ArrayItem)
+        else if (item.isArray())
             return true;
 
         return true;
@@ -133,21 +129,21 @@ public abstract class Item implements SerializableItem {
             BigDecimal value1 = Item.getNumericValue(v1, BigDecimal.class);
             BigDecimal value2 = Item.getNumericValue(v2, BigDecimal.class);
             result = value1.compareTo(value2);
-        } else if (v1 instanceof BooleanItem && v2 instanceof BooleanItem) {
-            Boolean value1 = new Boolean(((BooleanItem) v1).getBooleanValue());
-            Boolean value2 = new Boolean(((BooleanItem) v2).getBooleanValue());
+        } else if (v1.isBoolean() && v2.isBoolean()) {
+            Boolean value1 = new Boolean(v1.getBooleanValue());
+            Boolean value2 = new Boolean(v2.getBooleanValue());
             result = value1.compareTo(value2);
-        } else if (v1 instanceof StringItem&& v2 instanceof StringItem) {
-            String value1 = ((StringItem) v1).getStringValue();
-            String value2 = ((StringItem) v2).getStringValue();
+        } else if (v1.isString()&& v2.isString()) {
+            String value1 = v1.getStringValue();
+            String value2 = v2.getStringValue();
             result = value1.compareTo(value2);
         }
-        else if (v1 instanceof NullItem || v2 instanceof NullItem) {
+        else if (v1.isNull() || v2.isNull()) {
             // null equals null
-            if (v1 instanceof NullItem && v2 instanceof NullItem) {
+            if (v1.isNull() && v2.isNull()) {
                 result = 0;
             }
-            else if (v1 instanceof NullItem) {
+            else if (v1.isNull()) {
                 result = -1;
             }
             else{
@@ -196,7 +192,7 @@ public abstract class Item implements SerializableItem {
     };
 
     public String getStringValue() {
-        throw new RuntimeException("Item is not a string.");
+        throw new RuntimeException("getStringValue: Item is not a string.");
     };
 
     public boolean getBooleanValue() {

--- a/src/main/java/sparksoniq/jsoniq/item/ItemComparatorForSequences.java
+++ b/src/main/java/sparksoniq/jsoniq/item/ItemComparatorForSequences.java
@@ -19,13 +19,13 @@ public class ItemComparatorForSequences implements Comparator<Item>, Serializabl
             BigDecimal value1 = Item.getNumericValue(v1, BigDecimal.class);
             BigDecimal value2 = Item.getNumericValue(v2, BigDecimal.class);
             result = value1.compareTo(value2);
-        } else if (v1 instanceof BooleanItem && v2 instanceof BooleanItem) {
-            Boolean value1 = new Boolean(((BooleanItem) v1).getBooleanValue());
-            Boolean value2 = new Boolean(((BooleanItem) v2).getBooleanValue());
+        } else if (v1.isBoolean() && v2.isBoolean()) {
+            Boolean value1 = new Boolean(v1.getBooleanValue());
+            Boolean value2 = new Boolean(v2.getBooleanValue());
             result = value1.compareTo(value2);
-        } else if (v1 instanceof StringItem&& v2 instanceof StringItem) {
-            String value1 = ((StringItem) v1).getStringValue();
-            String value2 = ((StringItem) v2).getStringValue();
+        } else if (v1.isString()&& v2.isString()) {
+            String value1 = v1.getStringValue();
+            String value2 = v2.getStringValue();
             result = value1.compareTo(value2);
         } else {
             throw new SparksoniqRuntimeException(v1.serialize() + " " + v2.serialize());

--- a/src/main/java/sparksoniq/jsoniq/item/JsonItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/JsonItem.java
@@ -32,36 +32,6 @@ public abstract class JsonItem extends Item {
         return false;
     }
 
-    @Override
-    public String getStringValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("JSON items are not strings");
-    }
-
-    @Override
-    public boolean getBooleanValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("JSON items are not booleans");
-    }
-
-    @Override
-    public double getDoubleValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("JSON items are not doubles");
-    }
-
-    @Override
-    public int getIntegerValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("JSON items are not integers");
-    }
-
-    @Override
-    public BigDecimal getDecimalValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("JSON items are not decimals");
-    }
-
-    @Override
-    public int getSize() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Can not call getSize on non-array item");
-    }
-
     @Override public boolean isTypeOf(ItemType type) {
         if(type.getType().equals(ItemTypes.JSONItem) || type.getType().equals(ItemTypes.Item))
             return true;

--- a/src/main/java/sparksoniq/jsoniq/item/NullItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/NullItem.java
@@ -31,28 +31,9 @@ public class NullItem extends AtomicItem {
     public NullItem(){super();}
 
     @Override
-    public String getStringValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Null value exception");
-    }
-
-    @Override
-    public boolean getBooleanValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Null value exception");
-    }
-
-    @Override
-    public double getDoubleValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Null value exception");
-    }
-
-    @Override
-    public int getIntegerValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Null value exception");
-    }
-
-    @Override
-    public BigDecimal getDecimalValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Null value exception");
+    public boolean isNull()
+    {
+        return true;
     }
 
     @Override

--- a/src/main/java/sparksoniq/jsoniq/item/ObjectItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/ObjectItem.java
@@ -56,7 +56,6 @@ public class ObjectItem extends JsonItem{
      * ObjectItem constructor from the given map data structure.
      * For each key, the corresponding values list is turned into an ArrayItem if it contains more than a single element.
      * @param keyValuePairs LinkedHashMap -- this map implementation preserves order of the keys -- essential for functionality
-     * @param itemMetadata
      */
     public ObjectItem(LinkedHashMap<String, List<Item>> keyValuePairs) {
         super();
@@ -77,7 +76,7 @@ public class ObjectItem extends JsonItem{
                 valueList.add(value);
             }
             else {
-                throw new RuntimeException("Unexpected list size found");
+                throw new RuntimeException("Unexpected list size found.");
             }
         }
 

--- a/src/main/java/sparksoniq/jsoniq/item/ObjectItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/ObjectItem.java
@@ -77,11 +77,7 @@ public class ObjectItem extends JsonItem{
                 valueList.add(value);
             }
             else {
-                try {
-                    throw new OperationNotSupportedException("Unexpected list size found");
-                } catch (OperationNotSupportedException e) {
-                    e.printStackTrace();
-                }
+                throw new RuntimeException("Unexpected list size found");
             }
         }
 
@@ -98,21 +94,6 @@ public class ObjectItem extends JsonItem{
             else
                 frequencies.put(key, 1);
         }
-    }
-
-    @Override
-    public List<Item> getItems() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Objects are not arrays");
-    }
-
-    @Override
-    public Item getItemAt(int i) throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Objects are not arrays");
-    }
-
-    @Override
-    public void putItem(Item value) throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("Objects are not arrays");
     }
 
     @Override

--- a/src/main/java/sparksoniq/jsoniq/item/ObjectItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/ObjectItem.java
@@ -130,7 +130,7 @@ public class ObjectItem extends JsonItem{
         for (int i = 0; i < _keys.size(); ++i) {
             String key = _keys.get(i);
             Item value = _values.get(i);
-            boolean isStringValue = value instanceof StringItem;
+            boolean isStringValue = value.isString();
             sb.append("\"" + StringEscapeUtils.escapeJson(key) + "\"" + " : ");
             if(isStringValue)
             {

--- a/src/main/java/sparksoniq/jsoniq/item/StringItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/StringItem.java
@@ -44,26 +44,6 @@ public class StringItem extends AtomicItem{
         return _value;
     }
 
-    @Override
-    public boolean getBooleanValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("String value exception");
-    }
-
-    @Override
-    public double getDoubleValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("String value exception");
-    }
-
-    @Override
-    public int getIntegerValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("String value exception");
-    }
-
-    @Override
-    public BigDecimal getDecimalValue() throws OperationNotSupportedException {
-        throw new OperationNotSupportedException("String value exception");
-    }
-
     @Override public boolean isTypeOf(ItemType type) {
         if(type.getType().equals(ItemTypes.StringItem) || super.isTypeOf(type))
             return true;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/RuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/RuntimeIterator.java
@@ -162,25 +162,25 @@ public abstract class RuntimeIterator implements RuntimeIteratorInterface, KryoS
         if (iterator.hasNext()) {
             Item item = iterator.next();
             boolean result;
-            if (item instanceof BooleanItem)
-                result = ((BooleanItem) item).getBooleanValue();
+            if (item.isBoolean())
+                result = item.getBooleanValue();
             else if (isNumeric(item)) {
-                if (item instanceof IntegerItem)
-                    result = ((IntegerItem) item).getIntegerValue() != 0;
-                else if (item instanceof DoubleItem)
-                    result = ((DoubleItem) item).getDoubleValue() != 0;
-                else if (item instanceof DecimalItem)
-                    result = !((DecimalItem) item).getDecimalValue().equals(0);
+                if (item.isInteger())
+                    result = item.getIntegerValue() != 0;
+                else if (item.isDouble())
+                    result = item.getDoubleValue() != 0;
+                else if (item.isDecimal())
+                    result = !item.getDecimalValue().equals(0);
                 else {
                     throw new SparksoniqRuntimeException("Unexpected numeric type found while calculating effective boolean value.");
                 }
-            } else if (item instanceof NullItem)
+            } else if (item.isNull())
                 result = false;
-            else if (item instanceof StringItem)
-                result = !((StringItem) item).getStringValue().isEmpty();
-            else if (item instanceof ObjectItem)
+            else if (item.isString())
+                result = !item.getStringValue().isEmpty();
+            else if (item.isObject())
                 return true;
-            else if (item instanceof ArrayItem)
+            else if (item.isArray())
                 return true;
             else {
                 throw new SparksoniqRuntimeException("Unexpected item type found while calculating effective boolean value.");

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/control/SwitchRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/control/SwitchRuntimeIterator.java
@@ -65,10 +65,10 @@ public class SwitchRuntimeIterator extends LocalRuntimeIterator {
         Item testValue = getSingleItemOfTypeFromIterator(test, Item.class,
                 new NonAtomicKeyException("Switch test must be atomic", getMetadata().getExpressionMetadata()));
 
-        if (testValue instanceof ArrayItem) {
+        if (testValue != null && testValue.isArray()) {
             throw new NonAtomicKeyException("Invalid args. Switch condition can't be an array type", getMetadata().getExpressionMetadata());
         }
-        else if (testValue instanceof ObjectItem) {
+        else if (testValue != null && testValue.isObject()) {
             throw new NonAtomicKeyException("Invalid args. Switch condition  can't be an object type", getMetadata().getExpressionMetadata());
         }
 
@@ -76,10 +76,10 @@ public class SwitchRuntimeIterator extends LocalRuntimeIterator {
             Item caseValue = getSingleItemOfTypeFromIterator(caseKey, Item.class,
                     new NonAtomicKeyException("Switch case test must be atomic", getMetadata().getExpressionMetadata()));
 
-            if (caseValue instanceof ArrayItem) {
+            if (caseValue != null && caseValue.isArray()) {
                 throw new NonAtomicKeyException("Invalid args. Switch case can't be an array type", getMetadata().getExpressionMetadata());
             }
-            else if (caseValue instanceof ObjectItem) {
+            else if (caseValue != null && caseValue.isObject()) {
                 throw new NonAtomicKeyException("Invalid args. Switch case  can't be an object type", getMetadata().getExpressionMetadata());
             }
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArrayDescendantFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArrayDescendantFunctionIterator.java
@@ -70,17 +70,13 @@ public class ArrayDescendantFunctionIterator extends ArrayFunctionIterator {
 
     public void getDescendantArrays(List<Item> items) {
         for (Item item:items) {
-            try {
-                if (item.isArray()) {
-                    _nextResults.add(item);
-                    getDescendantArrays(item.getItems());
-                } else if (item.isObject()) {
-                    getDescendantArrays((List<Item>) item.getValues());
-                } else {
-                    // for atomic types: do nothing
-                }
-            } catch (OperationNotSupportedException e) {
-                e.printStackTrace();
+            if (item.isArray()) {
+                _nextResults.add(item);
+                getDescendantArrays(item.getItems());
+            } else if (item.isObject()) {
+                getDescendantArrays((List<Item>) item.getValues());
+            } else {
+                // for atomic types: do nothing
             }
         }
     }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArrayFlattenFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArrayFlattenFunctionIterator.java
@@ -67,11 +67,7 @@ public class ArrayFlattenFunctionIterator extends ArrayFunctionIterator {
     public void flatten(List<Item> items) {
         for (Item item:items) {
             if (item.isArray()) {
-                try {
-                    flatten(item.getItems());
-                } catch (OperationNotSupportedException e) {
-                    e.printStackTrace();
-                }
+                flatten(item.getItems());
             }
             else {
                 _nextResults.add(item);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArrayMembersFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/arrays/ArrayMembersFunctionIterator.java
@@ -49,11 +49,7 @@ public class ArrayMembersFunctionIterator extends ArrayFunctionIterator {
         while (_iterator.hasNext()) {
             Item item = _iterator.next();
             if (item.isArray()) {
-                try {
-                    _nextResults.addAll(item.getItems());
-                } catch (OperationNotSupportedException e) {
-                    e.printStackTrace();
-                }
+                _nextResults.addAll(item.getItems());
             }
         }
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectAccumulateFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectAccumulateFunctionIterator.java
@@ -25,21 +25,17 @@ public class ObjectAccumulateFunctionIterator extends ObjectFunctionIterator {
             for (Item item : items) {
                 // ignore non-object items
                 if (item.isObject()) {
-                    try {
-                        for (String key:item.getKeys()) {
-                            Item value = item.getItemByKey(key);
-                            if (!keyValuePairs.containsKey(key)) {
-                                List<Item> valueList = new ArrayList<>();
-                                valueList.add(value);
-                                keyValuePairs.put(key, valueList);
-                            }
-                            // store values for key collisions in a list
-                            else {
-                                keyValuePairs.get(key).add(value);
-                            }
+                    for (String key:item.getKeys()) {
+                        Item value = item.getItemByKey(key);
+                        if (!keyValuePairs.containsKey(key)) {
+                            List<Item> valueList = new ArrayList<>();
+                            valueList.add(value);
+                            keyValuePairs.put(key, valueList);
                         }
-                    } catch (OperationNotSupportedException e) {
-                        e.printStackTrace();
+                        // store values for key collisions in a list
+                        else {
+                            keyValuePairs.get(key).add(value);
+                        }
                     }
                 }
             }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectDescendantFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectDescendantFunctionIterator.java
@@ -68,17 +68,13 @@ public class ObjectDescendantFunctionIterator extends ObjectFunctionIterator {
 
     public void getDescendantObjects(List<Item> items) {
         for (Item item:items) {
-            try {
-                if (item.isArray()) {
-                    getDescendantObjects(item.getItems());
-                } else if (item.isObject()) {
-                    _nextResults.add(item);
-                    getDescendantObjects((List<Item>) item.getValues());
-                } else {
-                    // for atomic types: do nothing
-                }
-            } catch (OperationNotSupportedException e) {
-                e.printStackTrace();
+            if (item.isArray()) {
+                getDescendantObjects(item.getItems());
+            } else if (item.isObject()) {
+                _nextResults.add(item);
+                getDescendantObjects((List<Item>) item.getValues());
+            } else {
+                // for atomic types: do nothing
             }
         }
     }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectDescendantPairsFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectDescendantPairsFunctionIterator.java
@@ -67,26 +67,22 @@ public class ObjectDescendantPairsFunctionIterator extends ObjectFunctionIterato
 
     public void getDescendantPairs(List<Item> items) {
         for (Item item:items) {
-            try {
-                if (item.isArray()) {
-                    getDescendantPairs(item.getItems());
-                } else if (item.isObject()) {
-                    List<String> keys = item.getKeys();
-                    for (String key : keys) {
-                        Item value = item.getItemByKey(key);
+            if (item.isArray()) {
+                getDescendantPairs(item.getItems());
+            } else if (item.isObject()) {
+                List<String> keys = item.getKeys();
+                for (String key : keys) {
+                    Item value = item.getItemByKey(key);
 
-                        List<String> keyList = Collections.singletonList(key);
-                        List<Item> valueList = Collections.singletonList(value);
+                    List<String> keyList = Collections.singletonList(key);
+                    List<Item> valueList = Collections.singletonList(value);
 
-                        ObjectItem result = new ObjectItem(keyList, valueList, ItemMetadata.fromIteratorMetadata(getMetadata()));
-                        _nextResults.add(result);
-                        getDescendantPairs(valueList);
-                    }
-                } else {
-                    // do nothing
+                    ObjectItem result = new ObjectItem(keyList, valueList, ItemMetadata.fromIteratorMetadata(getMetadata()));
+                    _nextResults.add(result);
+                    getDescendantPairs(valueList);
                 }
-            } catch (OperationNotSupportedException e) {
-                e.printStackTrace();
+            } else {
+                // do nothing
             }
         }
     }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectIntersectFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectIntersectFunctionIterator.java
@@ -27,36 +27,32 @@ public class ObjectIntersectFunctionIterator extends ObjectFunctionIterator {
             for (Item item : items) {
                 // ignore non-object items
                 if (item.isObject()) {
-                    try {
-                        if (firstItem) {
-                            // add all key-value pairs of the first item
-                            for (String key:item.getKeys()) {
+                    if (firstItem) {
+                        // add all key-value pairs of the first item
+                        for (String key:item.getKeys()) {
+                            Item value = item.getItemByKey(key);
+                            ArrayList<Item> valueList = new ArrayList<>();
+                            valueList.add(value);
+                            keyValuePairs.put(key, valueList);
+                        }
+                        firstItem = false;
+                    }
+                    else {
+                        // iterate over existing keys in the map of results
+                        Iterator<String> keyIterator= keyValuePairs.keySet().iterator();
+                        while (keyIterator.hasNext()) {
+                            String key = keyIterator.next();
+                            // if the new item doesn't contain the same keys
+                            if (!item.getKeys().contains(key)){
+                                // remove the key from the map
+                                keyIterator.remove();
+                            }
+                            else {
+                                // add the matching key's value to the list
                                 Item value = item.getItemByKey(key);
-                                ArrayList<Item> valueList = new ArrayList<>();
-                                valueList.add(value);
-                                keyValuePairs.put(key, valueList);
-                            }
-                            firstItem = false;
-                        }
-                        else {
-                            // iterate over existing keys in the map of results
-                            Iterator<String> keyIterator= keyValuePairs.keySet().iterator();
-                            while (keyIterator.hasNext()) {
-                                String key = keyIterator.next();
-                                // if the new item doesn't contain the same keys
-                                if (!item.getKeys().contains(key)){
-                                    // remove the key from the map
-                                    keyIterator.remove();
-                                }
-                                else {
-                                    // add the matching key's value to the list
-                                    Item value = item.getItemByKey(key);
-                                    keyValuePairs.get(key).add(value);
-                                }
+                                keyValuePairs.get(key).add(value);
                             }
                         }
-                    } catch (OperationNotSupportedException e) {
-                        e.printStackTrace();
                     }
                 }
             }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectKeysFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectKeysFunctionIterator.java
@@ -54,10 +54,9 @@ public class ObjectKeysFunctionIterator extends ObjectFunctionIterator {
         while(_iterator.hasNext()) {
             Item item = _iterator.next();
             // ignore non-object items
-            if (item instanceof ObjectItem) {
-                ObjectItem objItem = (ObjectItem)item;
+            if (item.isObject()) {
                 StringItem result;
-                for (String key : objItem.getKeys()) {
+                for (String key : item.getKeys()) {
                     result = new StringItem(key);
                     // check if key was met earlier
                     if (!ItemUtil.listContainsItem(_prevResults, result))

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectProjectFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectProjectFunctionIterator.java
@@ -76,15 +76,11 @@ public class ObjectProjectFunctionIterator extends ObjectFunctionIterator {
         ArrayList<String> finalKeylist = new ArrayList<>();
         ArrayList<Item> finalValueList = new ArrayList<>();
         for (Item keyItem : keys) {
-            try {
-                String key = keyItem.getStringValue();
-                Item value = objItem.getItemByKey(key);
-                if (value != null) {
-                    finalKeylist.add(key);
-                    finalValueList.add(value);
-                }
-            } catch (OperationNotSupportedException e) {
-                throw new UnexpectedTypeException("Project function has non-string key args.", getMetadata());
+            String key = keyItem.getStringValue();
+            Item value = objItem.getItemByKey(key);
+            if (value != null) {
+                finalKeylist.add(key);
+                finalValueList.add(value);
             }
         }
         return new ObjectItem(finalKeylist, finalValueList, ItemMetadata.fromIteratorMetadata(getMetadata()));

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectProjectFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectProjectFunctionIterator.java
@@ -56,9 +56,8 @@ public class ObjectProjectFunctionIterator extends ObjectFunctionIterator {
 
         if (_iterator.hasNext()) {
             Item item = _iterator.next();
-            if (item instanceof ObjectItem) {
-                ObjectItem objItem = (ObjectItem) item;
-                _nextResult = getProjection(objItem, _projKeys);
+            if (item.isObject()) {
+                _nextResult = getProjection(item, _projKeys);
             } else {
                 _nextResult = item;
             }
@@ -72,7 +71,7 @@ public class ObjectProjectFunctionIterator extends ObjectFunctionIterator {
         }
     }
 
-    public ObjectItem getProjection(ObjectItem objItem, List<Item> keys) {
+    public Item getProjection(Item objItem, List<Item> keys) {
         ArrayList<String> finalKeylist = new ArrayList<>();
         ArrayList<Item> finalValueList = new ArrayList<>();
         for (Item keyItem : keys) {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectRemoveKeysFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectRemoveKeysFunctionIterator.java
@@ -38,6 +38,10 @@ public class ObjectRemoveKeysFunctionIterator extends ObjectFunctionIterator {
         }
         _removalKeys = new ArrayList<>();
         for (Item removalKeyItem : removalKeys) {
+            if(!removalKeyItem.isString())
+            {
+                throw new UnexpectedTypeException("Remove-keys function has non-string key args.", getMetadata());
+            }
             String removalKey = removalKeyItem.getStringValue();
             _removalKeys.add(removalKey);
         }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectRemoveKeysFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectRemoveKeysFunctionIterator.java
@@ -61,9 +61,8 @@ public class ObjectRemoveKeysFunctionIterator extends ObjectFunctionIterator {
 
         if (_iterator.hasNext()) {
             Item item = _iterator.next();
-            if (item instanceof ObjectItem) {
-                ObjectItem objItem = (ObjectItem) item;
-                _nextResult = removeKeys(objItem, _removalKeys);
+            if (item.isObject()) {
+                _nextResult = removeKeys(item, _removalKeys);
             } else {
                 _nextResult = item;
             }
@@ -77,7 +76,7 @@ public class ObjectRemoveKeysFunctionIterator extends ObjectFunctionIterator {
         }
     }
 
-    public ObjectItem removeKeys(ObjectItem objItem, List<String> removalKeys) {
+    public Item removeKeys(Item objItem, List<String> removalKeys) {
         ArrayList<String> finalKeylist = new ArrayList<>();
         ArrayList<Item> finalValueList = new ArrayList<>();
 

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectRemoveKeysFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectRemoveKeysFunctionIterator.java
@@ -38,12 +38,8 @@ public class ObjectRemoveKeysFunctionIterator extends ObjectFunctionIterator {
         }
         _removalKeys = new ArrayList<>();
         for (Item removalKeyItem : removalKeys) {
-            try {
-                String removalKey = removalKeyItem.getStringValue();
-                _removalKeys.add(removalKey);
-            } catch (OperationNotSupportedException e) {
-                throw new UnexpectedTypeException("Remove-keys function has non-string key args.", getMetadata());
-            }
+            String removalKey = removalKeyItem.getStringValue();
+            _removalKeys.add(removalKey);
         }
 
         setNextResult();

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectValuesFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/object/ObjectValuesFunctionIterator.java
@@ -48,9 +48,8 @@ public class ObjectValuesFunctionIterator extends ObjectFunctionIterator {
     public void setNextResult() {
         while (_iterator.hasNext()) {
             Item item = _iterator.next();
-            if (item instanceof ObjectItem) {
-                ObjectItem objItem = (ObjectItem) item;
-                _nextResults.addAll(objItem.getValues());
+            if (item.isObject()) {
+                _nextResults.addAll(item.getValues());
                 if (!(_nextResults.isEmpty())) {
                     break;
                 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/general/InsertBeforeFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/general/InsertBeforeFunctionIterator.java
@@ -54,15 +54,15 @@ public class InsertBeforeFunctionIterator extends LocalFunctionCallIterator {
                     getMetadata());
         }
         Item positionItem = positionIterator.next();
-        if (positionItem instanceof ArrayItem) {
+        if (positionItem.isArray()) {
             throw new NonAtomicKeyException(
                     "Invalid args. insert-before can't be performed with an array parameter as the position",
                     getMetadata().getExpressionMetadata());
-        } else if (positionItem instanceof ObjectItem) {
+        } else if (positionItem.isObject()) {
             throw new NonAtomicKeyException(
                     "Invalid args. insert-before can't be performed with an object parameter as the position",
                     getMetadata().getExpressionMetadata());
-        } else if (!(positionItem instanceof IntegerItem)) {
+        } else if (!(positionItem.isInteger())) {
             throw new UnexpectedTypeException(
                     "Invalid args. Position parameter should be an integer",
                     getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/general/RemoveFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/general/RemoveFunctionIterator.java
@@ -50,11 +50,11 @@ public class RemoveFunctionIterator extends LocalFunctionCallIterator {
                     getMetadata());
         }
         Item positionItem = positionIterator.next();
-        if (positionItem instanceof ArrayItem) {
+        if (positionItem.isArray()) {
             throw new NonAtomicKeyException(
                     "Invalid args. remove can't be performed with an array parameter as the position",
                     getMetadata().getExpressionMetadata());
-        } else if (positionItem instanceof ObjectItem) {
+        } else if (positionItem.isObject()) {
             throw new NonAtomicKeyException(
                     "Invalid args. remove can't be performed with an object parameter as the position",
                     getMetadata().getExpressionMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/general/SubsequenceFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/general/SubsequenceFunctionIterator.java
@@ -46,11 +46,11 @@ public class SubsequenceFunctionIterator extends LocalFunctionCallIterator {
                         getMetadata());
             }
             lengthItem = lengthIterator.next();
-            if (lengthItem instanceof ArrayItem) {
+            if (lengthItem.isArray()) {
                 throw new NonAtomicKeyException(
                         "Invalid args. subsequence can't be performed with an array parameter as the length",
                         getMetadata().getExpressionMetadata());
-            } else if (lengthItem instanceof ObjectItem) {
+            } else if (lengthItem.isObject()) {
                 throw new NonAtomicKeyException(
                         "Invalid args. subsequence can't be performed with an object parameter as the length",
                         getMetadata().getExpressionMetadata());
@@ -79,7 +79,7 @@ public class SubsequenceFunctionIterator extends LocalFunctionCallIterator {
                     getMetadata());
         }
         Item positionItem = positionIterator.next();
-        if (positionItem instanceof ArrayItem) {
+        if (positionItem.isArray()) {
             throw new NonAtomicKeyException(
                     "Invalid args. subsequence can't be performed with an array parameter as the position",
                     getMetadata().getExpressionMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/value/DeepEqualFunctionIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/sequences/value/DeepEqualFunctionIterator.java
@@ -50,9 +50,9 @@ public class DeepEqualFunctionIterator extends LocalFunctionCallIterator {
                 Item item1 = items1.get(i);
                 Item item2 = items2.get(i);
 
-                if (item1 instanceof ArrayItem) {
+                if (item1.isArray()) {
                     // if item types don't match
-                    if (!(item2 instanceof ArrayItem)) {
+                    if (!(item2.isArray())) {
                         return false;
                     } else {
                         // if types match, recursively check if array is deep-equal
@@ -63,17 +63,14 @@ public class DeepEqualFunctionIterator extends LocalFunctionCallIterator {
                             return false;
                         }
                     }
-                } else if (item1 instanceof ObjectItem) {
+                } else if (item1.isObject()) {
                     // if item types don't match
-                    if (!(item2 instanceof ObjectItem)) {
+                    if (!(item2.isObject())) {
                         return false;
                     } else {
                         // if types match, recursively check if object is deep-equal
-                        ObjectItem objItem1 = (ObjectItem)item1;
-                        ObjectItem objItem2 = (ObjectItem)item2;
-
-                        if (objItem1.getKeys().equals(objItem2.getKeys())) {
-                            if (!checkDeepEqual((List<Item>)objItem1.getValues(), (List<Item>)objItem2.getValues())) {
+                        if (item1.getKeys().equals(item2.getKeys())) {
+                            if (!checkDeepEqual((List<Item>)item1.getValues(), (List<Item>)item2.getValues())) {
                                 return false;
                             }
                         } else {

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/strings/StringJoinFunction.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/functions/strings/StringJoinFunction.java
@@ -31,7 +31,7 @@ public class StringJoinFunction extends LocalFunctionCallIterator {
 
             StringBuilder stringBuilder = new StringBuilder("");
             for (Item item : strings) {
-                if (!(item instanceof StringItem))
+                if (!(item.isString()))
                     throw new UnexpectedTypeException("String item expected", this._children.get(0).getMetadata());
                 stringBuilder = !stringBuilder.toString().isEmpty() ? stringBuilder.append(joinString.getStringValue()) : stringBuilder;
                 stringBuilder = stringBuilder.append(((StringItem) item).getStringValue());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/ComparisonOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/ComparisonOperationIterator.java
@@ -134,13 +134,13 @@ public class ComparisonOperationIterator extends BinaryOperationBaseIterator {
 
     public BooleanItem comparePair(Item left, Item right) {
 
-        if (left instanceof ArrayItem || right instanceof ArrayItem) {
+        if (left.isArray() || right.isArray()) {
             throw new NonAtomicKeyException("Invalid args. Comparison can't be performed on array type", getMetadata().getExpressionMetadata());
         }
-        else if (left instanceof ObjectItem || right instanceof ObjectItem) {
+        else if (left.isObject() || right.isObject()) {
             throw new NonAtomicKeyException("Invalid args. Comparison can't be performed on object type", getMetadata().getExpressionMetadata());
         }
-        if (left instanceof NullItem || right instanceof NullItem) {
+        if (left.isNull() || right.isNull()) {
             return compareItems(left, right);
         }
         else if (Item.isNumeric(left)) {
@@ -149,14 +149,14 @@ public class ComparisonOperationIterator extends BinaryOperationBaseIterator {
                         ", " + right.serialize(), getMetadata());
             return compareItems(left, right);
         }
-        else if (left instanceof StringItem) {
-            if (!(right instanceof StringItem))
+        else if (left.isString()) {
+            if (!(right.isString()))
                 throw new UnexpectedTypeException("Invalid args for string comparison " + left.serialize() +
                         ", " + right.serialize(), getMetadata());
             return compareItems(left, right);
         }
-        else if (left instanceof BooleanItem) {
-            if (!(right instanceof BooleanItem))
+        else if (left.isBoolean()) {
+            if (!right.isBoolean())
                 throw new UnexpectedTypeException("Invalid args for boolean comparison " + left.serialize() +
                         ", " + right.serialize(), getMetadata());
             return compareItems(left, right);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/UnaryOperationIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/operational/UnaryOperationIterator.java
@@ -51,12 +51,12 @@ public class UnaryOperationIterator extends UnaryOperationBaseIterator {
             if(this._operator== OperationalExpressionBase.Operator.MINUS)
             {
                 if(Item.isNumeric(child)){
-                    if(child instanceof IntegerItem)
-                        return new IntegerItem(-1 * ((IntegerItem)child).getIntegerValue());
-                    if(child instanceof DoubleItem)
-                        return new DoubleItem(-1 * ((DoubleItem)child).getDoubleValue());
-                    if(child instanceof DecimalItem)
-                        return new DecimalItem(((DecimalItem)child).getDecimalValue().multiply(new BigDecimal(-1)));
+                    if(child.isInteger())
+                        return new IntegerItem(-1 * child.getIntegerValue());
+                    if(child.isDouble())
+                        return new DoubleItem(-1 * child.getDoubleValue());
+                    if(child.isDecimal())
+                        return new DecimalItem(child.getDecimalValue().multiply(new BigDecimal(-1)));
                 }
                 throw new UnexpectedTypeException("Unary expression has non numeric args " +
                         child.serialize(), getMetadata());

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ObjectLookupClosure.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ObjectLookupClosure.java
@@ -18,7 +18,7 @@ public class ObjectLookupClosure implements FlatMapFunction<Item, Item> {
     public Iterator<Item> call(Item arg0) throws Exception {
         List<Item> results = new ArrayList<Item>();
 
-        if (!(arg0 instanceof ObjectItem))
+        if (!(arg0.isObject()))
             return results.iterator();
 
         Item item = arg0.getItemByKey(_key);

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ObjectLookupIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/postfix/ObjectLookupIterator.java
@@ -134,17 +134,16 @@ public class ObjectLookupIterator extends HybridRuntimeIterator {
 
         while (_iterator.hasNext()) {
             Item item = _iterator.next();
-            if (item instanceof ObjectItem) {
-                ObjectItem objItem = (ObjectItem) item;
+            if (item.isObject()) {
                 if (!_contextLookup) {
-                    Item result = objItem.getItemByKey(((StringItem) _lookupKey).getStringValue());
+                    Item result = item.getItemByKey(_lookupKey.getStringValue());
                     if (result != null) {
                         _nextResult = result;
                         break;
                     }
                 } else {
                     Item contextItem = _currentDynamicContext.getVariableValue("$$").get(0);
-                    _nextResult = objItem.getItemByKey(((StringItem)contextItem).getStringValue());
+                    _nextResult = item.getItemByKey(contextItem.getStringValue());
                 }
             }
         }

--- a/src/main/java/sparksoniq/jsoniq/tuple/FlworKey.java
+++ b/src/main/java/sparksoniq/jsoniq/tuple/FlworKey.java
@@ -80,8 +80,8 @@ public class FlworKey implements KryoSerializable {
             Item comparisonItem = flworKey.keyItems.get(index);
 
             // check for incorrect ordering inputs
-            if (currentItem instanceof ArrayItem || currentItem instanceof ObjectItem ||
-                    comparisonItem instanceof ArrayItem || comparisonItem instanceof ObjectItem) {
+            if (currentItem.isArray() || currentItem.isObject()||
+                    comparisonItem.isArray() || comparisonItem.isObject()) {
                 throw new SparksoniqRuntimeException("Non atomic key not allowed");
             }
             if ((currentItem != null && comparisonItem != null)

--- a/src/main/java/sparksoniq/jsoniq/tuple/FlworKey.java
+++ b/src/main/java/sparksoniq/jsoniq/tuple/FlworKey.java
@@ -80,8 +80,8 @@ public class FlworKey implements KryoSerializable {
             Item comparisonItem = flworKey.keyItems.get(index);
 
             // check for incorrect ordering inputs
-            if (currentItem.isArray() || currentItem.isObject()||
-                    comparisonItem.isArray() || comparisonItem.isObject()) {
+            if ((currentItem != null && currentItem.isArray()) || (currentItem != null && currentItem.isObject())||
+                    (comparisonItem != null && comparisonItem.isArray()) || (comparisonItem != null && comparisonItem.isObject())) {
                 throw new SparksoniqRuntimeException("Non atomic key not allowed");
             }
             if ((currentItem != null && comparisonItem != null)

--- a/src/main/java/sparksoniq/spark/closures/GroupByToPairMapClosure.java
+++ b/src/main/java/sparksoniq/spark/closures/GroupByToPairMapClosure.java
@@ -59,7 +59,7 @@ public class GroupByToPairMapClosure implements PairFunction<FlworTuple, FlworKe
                 groupVariableExpression.open(new DynamicContext(tuple));
                 while (groupVariableExpression.hasNext()) {
                     Item resultItem = groupVariableExpression.next();
-                    if (!Item.isAtomic(resultItem)) {
+                    if (!resultItem.isAtomic()) {
                         throw new NonAtomicKeyException("Group by keys must be atomics", _groupVariable.getIteratorMetadata().getExpressionMetadata());
                     }
                     newVariableResults.add(resultItem);

--- a/src/main/java/sparksoniq/spark/closures/OrderByMapToPairClosure.java
+++ b/src/main/java/sparksoniq/spark/closures/OrderByMapToPairClosure.java
@@ -49,7 +49,7 @@ public class OrderByMapToPairClosure implements PairFunction<FlworTuple, FlworKe
             orderByExpression.getExpression().open(new DynamicContext(tuple));
             while (orderByExpression.getExpression().hasNext()){
                 Item resultItem = orderByExpression.getExpression().next();
-                if(resultItem != null && !Item.isAtomic(resultItem))
+                if(resultItem != null && !resultItem.isAtomic())
                     throw new NonAtomicKeyException("Order by keys must be atomics",
                             orderByExpression.getIteratorMetadata().getExpressionMetadata());
                 results.add(resultItem);

--- a/src/main/java/sparksoniq/spark/iterator/flowr/GroupByClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/GroupByClauseSparkIterator.java
@@ -136,7 +136,7 @@ public class GroupByClauseSparkIterator extends SparkRuntimeTupleIterator {
                     groupVariableExpression.open(new DynamicContext(inputTuple));
                     while (groupVariableExpression.hasNext()) {
                         Item resultItem = groupVariableExpression.next();
-                        if (!Item.isAtomic(resultItem)) {
+                        if (!resultItem.isAtomic()) {
                             throw new NonAtomicKeyException("Group by keys must be atomics", _groupVariable.getIteratorMetadata().getExpressionMetadata());
                         }
                         newVariableResults.add(resultItem);

--- a/src/main/java/sparksoniq/spark/iterator/flowr/OrderByClauseSparkIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/flowr/OrderByClauseSparkIterator.java
@@ -138,7 +138,7 @@ public class OrderByClauseSparkIterator extends SparkRuntimeTupleIterator {
                 expression.open(tupleContext);
                 while (expression.hasNext()) {
                     Item resultItem = expression.next();
-                    if (resultItem != null && !Item.isAtomic(resultItem))
+                    if (resultItem != null && !resultItem.isAtomic())
                         throw new NonAtomicKeyException("Order by keys must be atomics",
                                 orderByExpression.getIteratorMetadata().getExpressionMetadata());
                     isFieldEmpty = false;

--- a/src/main/java/sparksoniq/spark/iterator/function/ParseJsonFunctionIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/function/ParseJsonFunctionIterator.java
@@ -54,21 +54,13 @@ public class ParseJsonFunctionIterator extends SparkFunctionCallIterator {
             RuntimeIterator urlIterator = this._children.get(0);
             urlIterator.open(context);
             if (this._children.size() == 1)
-                try {
-                    strings = SparkSessionManager.getInstance().getJavaSparkContext().textFile(urlIterator.next().getStringValue());
-                } catch (OperationNotSupportedException e) {
-                    throw new IllegalArgumentException("parse-json illegal argument");
-                }
+                strings = SparkSessionManager.getInstance().getJavaSparkContext().textFile(urlIterator.next().getStringValue());
             else {
                 RuntimeIterator partitionsIterator = this._children.get(1);
                 partitionsIterator.open(_currentDynamicContext);
-                try {
-                    strings = SparkSessionManager.getInstance().getJavaSparkContext().textFile(
-                            urlIterator.next().getStringValue(),
-                            partitionsIterator.next().getIntegerValue());
-                } catch (OperationNotSupportedException e) {
-                    throw new IllegalArgumentException("parse-json illegal argument");
-                }
+                strings = SparkSessionManager.getInstance().getJavaSparkContext().textFile(
+                        urlIterator.next().getStringValue(),
+                        partitionsIterator.next().getIntegerValue());
                 partitionsIterator.close();
             }
 

--- a/src/main/java/sparksoniq/spark/iterator/function/ParseTextFunctionIterator.java
+++ b/src/main/java/sparksoniq/spark/iterator/function/ParseTextFunctionIterator.java
@@ -55,21 +55,13 @@ public class ParseTextFunctionIterator extends SparkFunctionCallIterator {
             RuntimeIterator urlIterator = this._children.get(0);
             urlIterator.open(context);
             if (this._children.size() == 1)
-                try {
-                    strings = SparkSessionManager.getInstance().getJavaSparkContext().textFile(urlIterator.next().getStringValue());
-                } catch (OperationNotSupportedException e) {
-                    throw new IllegalArgumentException("parse-json illegal argument");
-                }
+                strings = SparkSessionManager.getInstance().getJavaSparkContext().textFile(urlIterator.next().getStringValue());
             else {
                 RuntimeIterator partitionsIterator = this._children.get(1);
                 partitionsIterator.open(_currentDynamicContext);
-                try {
-                    strings = SparkSessionManager.getInstance().getJavaSparkContext().textFile(
-                            urlIterator.next().getStringValue(),
-                            partitionsIterator.next().getIntegerValue());
-                } catch (OperationNotSupportedException e) {
-                    throw new IllegalArgumentException("parse-json illegal argument");
-                }
+                strings = SparkSessionManager.getInstance().getJavaSparkContext().textFile(
+                        urlIterator.next().getStringValue(),
+                        partitionsIterator.next().getIntegerValue());
                 partitionsIterator.close();
             }
 


### PR DESCRIPTION
The intent of such an API design, with all functions present in the top class, is that casts should not be necessary on the consumer side: the consumer of the Item API should not have to be aware of any of the involved subclasses. Method calls on an Item instance should be sufficient for all purposes for proper encapsulation.

This is fundamental as this API will be used and exposed to Sparksoniq users in language bindings later on, but this also will be directly useful to simplify our own code.

The casts were forced by exceptions thrown on improper API use to avoid propagating "throw" signatures, although this kind of exceptions should be used if they are part of the API itself. They are now replaced with RuntimeExceptions that indicate when the Item API's contract is not fulfilled.

This simplifies the code at many places, and instance of tests as well as casts are now superfluous.

This is a long PR, but the changes are very repetitive. This may also help with performance as we get rid of casting, exception try-catch as well as type testing.