### PR TITLE
Spark exception message

### DIFF
--- a/src/main/java/sparksoniq/io/shell/JiqsJLineShell.java
+++ b/src/main/java/sparksoniq/io/shell/JiqsJLineShell.java
@@ -20,6 +20,7 @@
 package sparksoniq.io.shell;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.spark.SparkException;
 import org.jline.reader.EndOfFileException;
 import org.jline.reader.LineReader;
 import org.jline.reader.LineReaderBuilder;
@@ -138,6 +139,10 @@ public class JiqsJLineShell {
         if (ex != null) {
             if (ex instanceof EndOfFileException) {
                 this.currentLine = this.EXIT_COMMAND;
+            } else if (ex instanceof SparkException) {
+                Throwable sparkExceptionCause = ex.getCause();
+                Throwable innerSparkExceptionCause = sparkExceptionCause.getCause();
+                output(ERROR_MESSAGE_PROMPT + innerSparkExceptionCause.getMessage());
             } else if (!(ex instanceof UserInterruptException)) {
                 output(ERROR_MESSAGE_PROMPT + ex.getMessage().split("\n")[0]);
             }


### PR DESCRIPTION
This PR is based on #249.

Error message handling for exceptions thrown within spark execution is improved. Previously custom exception's and their messages were not displayed to the user and spark implementation details were exposed as such:

Edit: The exception's root cause is fetched to give the most precise and relevant detail

[ERROR] Job aborted due to stage failure: Task 1 in stage 2.0 failed 1 times, most recent failure: Lost task 1.0 in stage 2.0 (TID 3, localhost, executor driver): org.apache.spark.SparkException: Failed to execute user defined function($anonfun$259: (array<binary>) => array<string>)

With this PR this turns into:

[ERROR] Error [err: XPDY0130 ] Order by expressions must return singleton atomics for each row
