### PR TITLE
Object constructor

### DIFF
--- a/src/main/java/sparksoniq/jsoniq/item/Item.java
+++ b/src/main/java/sparksoniq/jsoniq/item/Item.java
@@ -158,79 +158,53 @@ public abstract class Item implements SerializableItem {
         return compareItems(v1, v2) == 0;
     }
 
-    ;
-
     public List<Item> getItems() {
         throw new RuntimeException("Item is not an array.");
     }
-
-    ;
 
     public Item getItemAt(int i) {
         throw new RuntimeException("Item is not an array.");
     }
 
-    ;
-
     public void putItem(Item value) {
         throw new RuntimeException("Item is not an array.");
     }
-
-    ;
 
     public List<String> getKeys() {
         throw new RuntimeException("Item is not an object.");
     }
 
-    ;
-
     public Collection<? extends Item> getValues() {
         throw new RuntimeException("Item is not an object.");
     }
-
-    ;
 
     public Item getItemByKey(String s) {
         throw new RuntimeException("Item is not an object.");
     }
 
-    ;
-
     public void putItemByKey(String s, Item value) {
         throw new RuntimeException("Item is not an object.");
     }
-
-    ;
 
     public int getSize() {
         throw new RuntimeException("Item is not an array.");
     }
 
-    ;
-
     public String getStringValue() {
         throw new RuntimeException("Item is not a string.");
     }
-
-    ;
 
     public boolean getBooleanValue() {
         throw new RuntimeException("Item is not a boolean.");
     }
 
-    ;
-
     public double getDoubleValue() {
         throw new RuntimeException("Item is not a double.");
     }
 
-    ;
-
     public int getIntegerValue() {
         throw new RuntimeException("Item is not an integer.");
     }
-
-    ;
 
     public BigDecimal getDecimalValue() {
         throw new RuntimeException("Item is not a big decimal.");

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ObjectConstructorRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/primary/ObjectConstructorRuntimeIterator.java
@@ -20,11 +20,11 @@
 package sparksoniq.jsoniq.runtime.iterator.primary;
 
 import sparksoniq.exceptions.IteratorFlowException;
+import sparksoniq.exceptions.UnexpectedTypeException;
 import sparksoniq.jsoniq.item.ArrayItem;
 import sparksoniq.jsoniq.item.Item;
 import sparksoniq.jsoniq.item.NullItem;
 import sparksoniq.jsoniq.item.ObjectItem;
-import sparksoniq.jsoniq.item.StringItem;
 import sparksoniq.jsoniq.item.metadata.ItemMetadata;
 import sparksoniq.jsoniq.runtime.iterator.LocalRuntimeIterator;
 import sparksoniq.jsoniq.runtime.iterator.RuntimeIterator;
@@ -93,9 +93,16 @@ public class ObjectConstructorRuntimeIterator extends LocalRuntimeIterator {
 
                 for (RuntimeIterator keyIterator : this._keys) {
                     keyIterator.open(this._currentDynamicContext);
-                    keys.add((keyIterator.next()).getStringValue());
+                    if (!keyIterator.hasNext()) {
+                        throw new IteratorFlowException("A key cannot be the empty sequence", getMetadata());
+                    }
+                    Item key = keyIterator.next();
+                    if (!key.isString()) {
+                        throw new UnexpectedTypeException("Key provided for object creation must be of type String", getMetadata());
+                    }
+                    keys.add(key.getStringValue());
                     if (keyIterator.hasNext())
-                        throw new IteratorFlowException("Object value must return one item!", getMetadata());
+                        throw new IteratorFlowException("A key cannot be a sequence of more than one item", getMetadata());
                     keyIterator.close();
                 }
                 this._hasNext = false;

--- a/src/main/resources/test_files/runtime/ErrorNonStringKey.iq
+++ b/src/main/resources/test_files/runtime/ErrorNonStringKey.iq
@@ -1,2 +1,2 @@
-(:JIQS: ShouldCrash; ErrorCode="XPDY0130"; ErrorMetadata="LINE:2:COLUMN:0:" :)
+(:JIQS: ShouldCrash; ErrorCode="XPTY0004"; ErrorMetadata="LINE:2:COLUMN:0:" :)
 { [ 1 ] : 1 }


### PR DESCRIPTION
Object construction would cause exceptions for empty sequences used as values. I have added a size check and put in NullItem for empty sequences. I believe that this behavior is compliant with JSONiq specifications at:
http://www.jsoniq.org/docs/JSONiq/html-single/index.html#idm71239520

> And do not worry about the value expression: if it is is empty, null will be used as a value, and if it contains two items or more, they will be wrapped into an array. 

Error codes added to exceptions thrown within Item class
