### PR TITLE
Fix keySet issue with older org.json.

### DIFF
--- a/docs/Getting started.md
+++ b/docs/Getting started.md
@@ -44,7 +44,7 @@ Create, in the same directory as Sparksoniq, a file data.json and put the follow
 In a shell, from the directory where the sparksoniq .jar lies, type, all on one line:
 
     spark-submit --class sparksoniq.ShellStart --master local[*] --deploy-mode client
-                 sparksoniq-0.9.6-with-antlr-4.7.jar
+                 sparksoniq-0.9.7-with-antlr-4.7.jar
                  
 The Sparksoniq shell appears:
 

--- a/docs/Run on a cluster.md
+++ b/docs/Run on a cluster.md
@@ -6,19 +6,19 @@ simply by modifying the command line parameters as documented [here for spark-su
 If the Spark cluster is running on yarn, then the --master option must be changed from local[\*] to yarn compared to the getting started guide.
 
     spark-submit --class sparksoniq.ShellStart --master yarn --deploy-mode client
-                 sparksoniq-0.9.6-with-antlr-4.7.jar
+                 sparksoniq-0.9.7-with-antlr-4.7.jar
                  
 You can also adapt the number of executors, etc.
 
     spark-submit --class sparksoniq.ShellStart --master yarn --deploy-mode client
                  --num-executors 30 --executor-cores 3 --executor-memory 10g
-                 sparksoniq-0.9.6-with-antlr-4.7.jar
+                 sparksoniq-0.9.7-with-antlr-4.7.jar
 
 The size limit for materialization can also be made higher with --result-size (the default is 100). This affects the number of items displayed on the shells as an answer to a query, as well as any materializations happening within the query with push-down is not supported. Warnings are issued if the cap is reached.
 
     spark-submit --class sparksoniq.ShellStart --master yarn --deploy-mode client
                  --num-executors 30 --executor-cores 3 --executor-memory 10g
-                 sparksoniq-0.9.6-with-antlr-4.7.jar
+                 sparksoniq-0.9.7-with-antlr-4.7.jar
                  --result-size 10000
 
 ## Creation functions

--- a/docs/install.md
+++ b/docs/install.md
@@ -60,13 +60,13 @@ Once the ANTLR sources have been generated, you can compile the entire project l
 
     $ mvn clean compile assembly:single
     
-After successful completion, you can check the `target` directory, which should contain the compiled classes as well as the JAR file `jsoniq-spark-app-0.9.6-jar-with-dependencies.jar`.
+After successful completion, you can check the `target` directory, which should contain the compiled classes as well as the JAR file `jsoniq-spark-app-0.9.7-jar-with-dependencies.jar`.
     
 ## Running locally
 
 The most straightforward to test if the above steps were successful is to run the Sparksoniq shell locally, like so:
 
-    $ spark-submit --class sparksoniq.ShellStart --master local[2] --deploy-mode client target/jsoniq-spark-app-0.9.6-jar-with-dependencies.jar
+    $ spark-submit --class sparksoniq.ShellStart --master local[2] --deploy-mode client target/jsoniq-spark-app-0.9.7-jar-with-dependencies.jar
 
 The Sparksoniq shell should start:
 
@@ -113,6 +113,6 @@ This is it. Sparksoniq is step and ready to go locally. You can now move on to a
 
 You can also try to run the Sparksoniq shell on a cluster if you have one available and configured -- this is done in the same way as any other `spark-submit` command:
 
-    $ spark-submit --class sparksoniq.ShellStart --master yarn --deploy-mode client --num-executors 40 jsoniq-spark-app-0.9.6-jar-with-dependencies.jar
+    $ spark-submit --class sparksoniq.ShellStart --master yarn --deploy-mode client --num-executors 40 jsoniq-spark-app-0.9.7-jar-with-dependencies.jar
     
 More details are provided in the rest of the documentation.

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>jsoniq-spark</groupId>
     <artifactId>jsoniq-spark-app</artifactId>
-    <version>0.9.6</version>
+    <version>0.9.7</version>
 
     <packaging>jar</packaging>
 

--- a/src/main/java/sparksoniq/io/json/JiqsItemParser.java
+++ b/src/main/java/sparksoniq/io/json/JiqsItemParser.java
@@ -64,7 +64,7 @@ public class JiqsItemParser implements Serializable {
             }
             if (object instanceof JSONObject) {
                 JSONObject currentObject = (JSONObject) object;
-                int numberOfValues = currentObject.keySet().size();
+                int numberOfValues = currentObject.length();
                 List<String> keys = new ArrayList<>(numberOfValues);
                 List<Item> values = new ArrayList<>(numberOfValues);
                 Iterator<String> keyIterator = currentObject.keys();


### PR DESCRIPTION
The only material fix (besides upgrading version to 0.9.7) is to no longer use JSONObject.keySet(), because some Spark environments have old versions of org.json. This fix makes us backward compatible with all environments.