### PR TITLE
Clean up CLI.

### DIFF
--- a/src/main/java/sparksoniq/JsoniqQueryExecutor.java
+++ b/src/main/java/sparksoniq/JsoniqQueryExecutor.java
@@ -94,7 +94,7 @@ public class JsoniqQueryExecutor {
         }
         long endTime = System.currentTimeMillis();
         long totalTime = endTime - startTime;
-        if (!_configuration.getLogPath().isEmpty()) {
+        if (_configuration.getLogPath() != null) {
             writeTimeLog(totalTime);
         }
     }
@@ -126,7 +126,7 @@ public class JsoniqQueryExecutor {
         }
         long endTime = System.currentTimeMillis();
         long totalTime = endTime - startTime;
-        if (!_configuration.getLogPath().isEmpty()) {
+        if (_configuration.getLogPath() != null) {
             writeTimeLog(totalTime);
         }
     }

--- a/src/main/java/sparksoniq/JsoniqQueryExecutor.java
+++ b/src/main/java/sparksoniq/JsoniqQueryExecutor.java
@@ -61,9 +61,11 @@ import java.util.List;
 public class JsoniqQueryExecutor {
     public static final String TEMP_QUERY_FILE_NAME = "Temp_Query";
     private SparksoniqRuntimeConfiguration _configuration;
+    private boolean _useLocalOutputLog;
 
-    public JsoniqQueryExecutor(SparksoniqRuntimeConfiguration configuration) {
+    public JsoniqQueryExecutor(boolean useLocalOutputLog, SparksoniqRuntimeConfiguration configuration) {
         _configuration = configuration;
+        _useLocalOutputLog = useLocalOutputLog;
         SparkSessionManager.COLLECT_ITEM_LIMIT = configuration.getResultSizeCap();
     }
 
@@ -106,7 +108,7 @@ public class JsoniqQueryExecutor {
         // generate iterators
         RuntimeIterator result = generateRuntimeIterators(visitor.getQueryExpression());
         // collect output in memory and write to filesystem from java
-        if (_configuration.isLocal()) {
+        if (_useLocalOutputLog) {
             String output = runIterators(result);
             org.apache.hadoop.fs.FileSystem fileSystem = org.apache.hadoop.fs.FileSystem
                     .get(SparkSessionManager.getInstance().getJavaSparkContext().hadoopConfiguration());

--- a/src/main/java/sparksoniq/Main.java
+++ b/src/main/java/sparksoniq/Main.java
@@ -37,21 +37,32 @@ public class Main {
         try {
             sparksoniqConf = new SparksoniqRuntimeConfiguration(args);
 
-            // Initialize
-            initializeApplication();
-            
             if(sparksoniqConf.isShell())
             {
+                initializeApplication();
                 launchShell(sparksoniqConf);
             } else if(sparksoniqConf.getQueryPath() != null) {
+                initializeApplication();
                 runQueryExecutor(sparksoniqConf);
             } else {
-                System.out.println("Sparksoniq version 0.9.7.");
+                System.out.println("************************");
+                System.out.println("Sparksoniq version 0.9.7");
+                System.out.println("************************");
                 System.out.println("Usage:");
+                System.out.println("spark-submit <Spark arguments> <path to sparksoniq jar> <Sparksoniq arguments>");
+                System.out.println("");
+                System.out.println("Example usage:");
                 System.out.println("spark-submit sparksoniq-0.9.7.jar --shell yes");
-                System.out.println("spark-submit sparksoniq-0.9.7.jar --query-path my-query.jq");
-                System.out.println("spark-submit sparksoniq-0.9.7.jar --query-path my-query.jq --output-path my-output.json");
-                System.out.println("spark-submit sparksoniq-0.9.7.jar --query-path my-query.jq --output-path my-output.json --log-path my-log.txt");
+                System.out.println("spark-submit --master local[*] sparksoniq-0.9.7.jar --shell yes");
+                System.out.println("spark-submit --master local[2] sparksoniq-0.9.7.jar --shell yes");
+                System.out.println("spark-submit --master local[*] --driver-memory 10G sparksoniq-0.9.7.jar --shell yes");
+                System.out.println("");
+                System.out.println("spark-submit --master yarn sparksoniq-0.9.7.jar --shell yes");
+                System.out.println("spark-submit --master yarn --executor-cores 3 --executor-memory 5G sparksoniq-0.9.7.jar --shell yes");
+                System.out.println("spark-submit --master local[*] sparksoniq-0.9.7.jar --query-path my-query.jq");
+                System.out.println("spark-submit --master local[*] sparksoniq-0.9.7.jar --query-path my-query.jq");
+                System.out.println("spark-submit --master yarn --executor-cores 3 --executor-memory 5G sparksoniq-0.9.7.jar --query-path hdfs:///my-query.jq --output-path hdfs:///my-output.json");
+                System.out.println("spark-submit --master local[*] sparksoniq-0.9.7.jar --query-path my-query.jq --output-path my-output.json --log-path my-log.txt");
             }
         } catch (Exception ex) {
             throw ex;

--- a/src/main/java/sparksoniq/Main.java
+++ b/src/main/java/sparksoniq/Main.java
@@ -65,7 +65,7 @@ public class Main {
                 System.out.println("spark-submit --master local[*] sparksoniq-0.9.7.jar --query-path my-query.jq --output-path my-output.json --log-path my-log.txt");
             }
         } catch (Exception ex) {
-            throw ex;
+            throw new CliException(ex.getMessage());
         }
 
     }

--- a/src/main/java/sparksoniq/Main.java
+++ b/src/main/java/sparksoniq/Main.java
@@ -43,11 +43,18 @@ public class Main {
             if(sparksoniqConf.isShell())
             {
                 launchShell(sparksoniqConf);
-            } else {
+            } else if(sparksoniqConf.getQueryPath() != null) {
                 runQueryExecutor(sparksoniqConf);
+            } else {
+                System.out.println("Sparksoniq version 0.9.7.");
+                System.out.println("Usage:");
+                System.out.println("spark-submit sparksoniq-0.9.7.jar --shell yes");
+                System.out.println("spark-submit sparksoniq-0.9.7.jar --query-path my-query.jq");
+                System.out.println("spark-submit sparksoniq-0.9.7.jar --query-path my-query.jq --output-path my-output.json");
+                System.out.println("spark-submit sparksoniq-0.9.7.jar --query-path my-query.jq --output-path my-output.json --log-path my-log.txt");
             }
         } catch (Exception ex) {
-            throw new CliException(ex.getMessage());
+            throw ex;
         }
 
     }

--- a/src/main/java/sparksoniq/Main.java
+++ b/src/main/java/sparksoniq/Main.java
@@ -55,7 +55,7 @@ public class Main {
     private static void runQueryExecutor(SparksoniqRuntimeConfiguration sparksoniqConf) throws IOException {
         
         JsoniqQueryExecutor translator;
-        translator = new JsoniqQueryExecutor(sparksoniqConf);
+        translator = new JsoniqQueryExecutor(sparksoniqConf.isLocal(), sparksoniqConf);
         if (sparksoniqConf.isLocal()) {
             System.out.println("Running in local mode");
             translator.runLocal(sparksoniqConf.getQueryPath(), sparksoniqConf.getOutputPath());

--- a/src/main/java/sparksoniq/Main.java
+++ b/src/main/java/sparksoniq/Main.java
@@ -26,7 +26,6 @@ import sparksoniq.io.shell.JiqsJLineShell;
 import sparksoniq.spark.SparkSessionManager;
 
 import java.io.IOException;
-import java.util.HashMap;
 
 public class Main {
     public static JiqsJLineShell terminal = null;

--- a/src/main/java/sparksoniq/ShellStart.java
+++ b/src/main/java/sparksoniq/ShellStart.java
@@ -45,8 +45,8 @@ spark-submit --class sparksoniq.ShellStart  --master local[*]  --deploy-mode cli
 public class ShellStart {
     public static void main(String[] args) throws IOException {
         String[] newargs = Arrays.copyOf(args, args.length + 2);
-        newargs[args.length-2] = "shell";
-        newargs[args.length-1] = "yes";
+        newargs[args.length] = "--shell";
+        newargs[args.length+1] = "yes";
         Main.main(newargs);
     }
 }

--- a/src/main/java/sparksoniq/ShellStart.java
+++ b/src/main/java/sparksoniq/ShellStart.java
@@ -25,6 +25,8 @@ import sparksoniq.io.shell.JiqsJLineShell;
 import sparksoniq.spark.SparkSessionManager;
 
 import java.io.IOException;
+import java.lang.reflect.Array;
+import java.util.Arrays;
 import java.util.HashMap;
 
 /*
@@ -41,24 +43,10 @@ spark-submit --class sparksoniq.ShellStart  --master local[*]  --deploy-mode cli
  */
 
 public class ShellStart {
-    public static JiqsJLineShell terminal = null;
-
     public static void main(String[] args) throws IOException {
-        HashMap<String, String> arguments;
-        try {
-            arguments = SparksoniqRuntimeConfiguration.processCommandLineArgs(args);
-        } catch (CliException ex) {
-            System.out.println(ex.getMessage());
-            return;
-        }
-
-        SparkSessionManager.getInstance().initializeConfigurationAndSession();
-        if (arguments.containsKey("result-size")) {
-            int itemLimit = Integer.parseInt(arguments.get("result-size"));
-            terminal = new JiqsJLineShell(new SparksoniqRuntimeConfiguration(arguments), itemLimit);
-            terminal.launch();
-        } else
-            terminal = new JiqsJLineShell(new SparksoniqRuntimeConfiguration(arguments));
-        terminal.launch();
+        String[] newargs = Arrays.copyOf(args, args.length + 2);
+        newargs[args.length-2] = "shell";
+        newargs[args.length-1] = "yes";
+        Main.main(newargs);
     }
 }

--- a/src/main/java/sparksoniq/ShellStart.java
+++ b/src/main/java/sparksoniq/ShellStart.java
@@ -19,15 +19,8 @@
  */
 package sparksoniq;
 
-import sparksoniq.config.SparksoniqRuntimeConfiguration;
-import sparksoniq.exceptions.CliException;
-import sparksoniq.io.shell.JiqsJLineShell;
-import sparksoniq.spark.SparkSessionManager;
-
 import java.io.IOException;
-import java.lang.reflect.Array;
 import java.util.Arrays;
-import java.util.HashMap;
 
 /*
 GENERIC LAUNCH COMMAND

--- a/src/main/java/sparksoniq/config/SparksoniqRuntimeConfiguration.java
+++ b/src/main/java/sparksoniq/config/SparksoniqRuntimeConfiguration.java
@@ -20,6 +20,7 @@
 package sparksoniq.config;
 
 import sparksoniq.exceptions.CliException;
+import sparksoniq.spark.SparkSessionManager;
 
 import java.util.HashMap;
 
@@ -29,8 +30,9 @@ public class SparksoniqRuntimeConfiguration {
     private static final String ARGUMENT_FORMAT_ERROR_MESSAGE = "Invalid argument format. Required format: --property value";
     private HashMap<String, String> _arguments;
 
-    public SparksoniqRuntimeConfiguration(HashMap<String, String> arguments) {
-        this._arguments = arguments;
+    public SparksoniqRuntimeConfiguration(String[] args) {
+        this._arguments = new HashMap<String, String>();
+        processCommandLineArgs(args);
     }
 
     public static HashMap<String, String> processCommandLineArgs(String[] args) {
@@ -48,6 +50,46 @@ public class SparksoniqRuntimeConfiguration {
             return this._arguments.get(key);
         else
             return null;
+    }
+
+    public String getOutputPath() {
+        if (this._arguments.containsKey("output-path"))
+            return this._arguments.get("output-path");
+        else
+            return null;
+    }
+
+    public String getLogPath() {
+        if (this._arguments.containsKey("log-path"))
+            return this._arguments.get("log-path");
+        else
+            return null;
+    }
+
+    public String getQueryPath() {
+        if (this._arguments.containsKey("query-path"))
+            return this._arguments.get("query-path");
+        else
+            return null;
+    }
+
+    public int getResultSizeCap() {
+        if (this._arguments.containsKey("result-size"))
+            return Integer.parseInt(this._arguments.get("result-size"));
+        else
+            return 200;
+    }
+
+    public boolean isShell() {
+        if (this._arguments.containsKey("shell"))
+            return _arguments.get("shell") == "yes";
+        else
+            return false;
+    }
+    
+    public boolean isLocal() {
+        String masterConfig = SparkSessionManager.getInstance().getJavaSparkContext().getConf().get("spark.master");
+        return masterConfig.contains("local");
     }
 
     @Override

--- a/src/main/java/sparksoniq/config/SparksoniqRuntimeConfiguration.java
+++ b/src/main/java/sparksoniq/config/SparksoniqRuntimeConfiguration.java
@@ -75,7 +75,6 @@ public class SparksoniqRuntimeConfiguration {
     }
 
     public boolean isShell() {
-        System.out.println(_arguments.get("shell"));
         if (this._arguments.containsKey("shell"))
             return _arguments.get("shell").equals("yes");
         else
@@ -90,7 +89,8 @@ public class SparksoniqRuntimeConfiguration {
     @Override
     public String toString() {
         String result = "";
-        result += "Item Display Limit: " + (_arguments.getOrDefault("result-size", "-")) + "\n" +
+        result += "Master: " + SparkSessionManager.getInstance().getJavaSparkContext().getConf().get("spark.master") + "\n" +
+                "Item Display Limit: " + (_arguments.getOrDefault("result-size", "-")) + "\n" +
                 "Output Path: " + (_arguments.getOrDefault("output-path", "-")) + "\n" +
                 "Log Path: " + (_arguments.getOrDefault("log-path", "-")) + "\n" +
                 "Query Path : " + (_arguments.getOrDefault("query-path", "-")) + "\n";

--- a/src/main/java/sparksoniq/config/SparksoniqRuntimeConfiguration.java
+++ b/src/main/java/sparksoniq/config/SparksoniqRuntimeConfiguration.java
@@ -31,18 +31,12 @@ public class SparksoniqRuntimeConfiguration {
     private HashMap<String, String> _arguments;
 
     public SparksoniqRuntimeConfiguration(String[] args) {
-        this._arguments = new HashMap<String, String>();
-        processCommandLineArgs(args);
-    }
-
-    public static HashMap<String, String> processCommandLineArgs(String[] args) {
-        HashMap<String, String> argumentMap = new HashMap<>();
+        _arguments = new HashMap<>();
         for (int i = 0; i < args.length; i += 2)
             if (args[i].startsWith(ARGUMENT_PREFIX))
-                argumentMap.put(args[i].trim().replace(ARGUMENT_PREFIX, ""), args[i + 1]);
+                _arguments.put(args[i].trim().replace(ARGUMENT_PREFIX, ""), args[i + 1]);
             else
                 throw new CliException(ARGUMENT_FORMAT_ERROR_MESSAGE);
-        return argumentMap;
     }
 
     public String getConfigurationArgument(String key) {
@@ -81,8 +75,9 @@ public class SparksoniqRuntimeConfiguration {
     }
 
     public boolean isShell() {
+        System.out.println(_arguments.get("shell"));
         if (this._arguments.containsKey("shell"))
-            return _arguments.get("shell") == "yes";
+            return _arguments.get("shell").equals("yes");
         else
             return false;
     }

--- a/src/main/java/sparksoniq/io/shell/JiqsJLineShell.java
+++ b/src/main/java/sparksoniq/io/shell/JiqsJLineShell.java
@@ -123,7 +123,7 @@ public class JiqsJLineShell {
 //                .parser(new JiqsJlineParser())
                 .build();
         PrintWriter outputWriter = new PrintWriter(terminal.output());
-        jsoniqQueryExecutor = new JsoniqQueryExecutor(false, _configuration.getResultSizeCap());
+        jsoniqQueryExecutor = new JsoniqQueryExecutor(false, _configuration);
     }
 
     private void handleException(Exception ex) {

--- a/src/main/java/sparksoniq/io/shell/JiqsJLineShell.java
+++ b/src/main/java/sparksoniq/io/shell/JiqsJLineShell.java
@@ -46,7 +46,6 @@ public class JiqsJLineShell {
     private static final String ERROR_MESSAGE_PROMPT = "[ERROR] ";
     private final boolean _printTime;
     private final SparksoniqRuntimeConfiguration _configuration;
-    private int _itemLimit;
     private LineReader lineReader;
     private JsoniqQueryExecutor jsoniqQueryExecutor;
     private boolean queryStarted;
@@ -57,14 +56,6 @@ public class JiqsJLineShell {
 
     public JiqsJLineShell(SparksoniqRuntimeConfiguration configuration) throws IOException {
         this._configuration = configuration;
-        this._itemLimit = 100;
-        initialize();
-        this._printTime = true;
-    }
-
-    public JiqsJLineShell(SparksoniqRuntimeConfiguration configuration, int itemLimit) throws IOException {
-        this._configuration = configuration;
-        this._itemLimit = itemLimit;
         initialize();
         this._printTime = true;
     }
@@ -132,7 +123,7 @@ public class JiqsJLineShell {
 //                .parser(new JiqsJlineParser())
                 .build();
         PrintWriter outputWriter = new PrintWriter(terminal.output());
-        jsoniqQueryExecutor = new JsoniqQueryExecutor(false, _itemLimit);
+        jsoniqQueryExecutor = new JsoniqQueryExecutor(false, _configuration.getResultSizeCap());
     }
 
     private void handleException(Exception ex) {

--- a/src/main/java/sparksoniq/jsoniq/item/DoubleItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/DoubleItem.java
@@ -19,8 +19,6 @@
  */
 package sparksoniq.jsoniq.item;
 
-import java.math.BigDecimal;
-
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;

--- a/src/main/java/sparksoniq/jsoniq/item/IntegerItem.java
+++ b/src/main/java/sparksoniq/jsoniq/item/IntegerItem.java
@@ -19,8 +19,6 @@
  */
 package sparksoniq.jsoniq.item;
 
-import java.math.BigDecimal;
-
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/HybridRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/HybridRuntimeIterator.java
@@ -20,6 +20,8 @@
 package sparksoniq.jsoniq.runtime.iterator;
 
 import org.apache.spark.api.java.JavaRDD;
+
+import sparksoniq.Main;
 import sparksoniq.ShellStart;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.io.json.JiqsItemParser;
@@ -92,11 +94,11 @@ public abstract class HybridRuntimeIterator extends RuntimeIterator {
             if (SparkSessionManager.LIMIT_COLLECT()) {
                 result = _rdd.take(SparkSessionManager.COLLECT_ITEM_LIMIT);
                 if (result.size() == SparkSessionManager.COLLECT_ITEM_LIMIT) {
-                    if (ShellStart.terminal == null) {
+                    if (Main.terminal == null) {
                         System.out.println("Results have been truncated to:" + SparkSessionManager.COLLECT_ITEM_LIMIT
                                 + " items. This value can be configured with the --result-size parameter at startup.\n");
                     } else {
-                        ShellStart.terminal.output("\nWarning: Results have been truncated to: " + SparkSessionManager.COLLECT_ITEM_LIMIT
+                        Main.terminal.output("\nWarning: Results have been truncated to: " + SparkSessionManager.COLLECT_ITEM_LIMIT
                                 + " items. This value can be configured with the --result-size parameter at startup.\n");
                     }
                 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/HybridRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/HybridRuntimeIterator.java
@@ -22,7 +22,6 @@ package sparksoniq.jsoniq.runtime.iterator;
 import org.apache.spark.api.java.JavaRDD;
 
 import sparksoniq.Main;
-import sparksoniq.ShellStart;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.io.json.JiqsItemParser;
 import sparksoniq.jsoniq.item.Item;

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/SparkRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/SparkRuntimeIterator.java
@@ -20,6 +20,8 @@
 package sparksoniq.jsoniq.runtime.iterator;
 
 import org.apache.spark.api.java.JavaRDD;
+
+import sparksoniq.Main;
 import sparksoniq.ShellStart;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.io.json.JiqsItemParser;
@@ -67,11 +69,11 @@ public abstract class SparkRuntimeIterator extends RuntimeIterator {
             if (SparkSessionManager.LIMIT_COLLECT()) {
                 result = _rdd.take(SparkSessionManager.COLLECT_ITEM_LIMIT);
                 if (result.size() == SparkSessionManager.COLLECT_ITEM_LIMIT) {
-                    if (ShellStart.terminal == null) {
+                    if (Main.terminal == null) {
                         System.out.println("Results have been truncated to:" + SparkSessionManager.COLLECT_ITEM_LIMIT
                                 + " items. This value can be configured with the --result-size parameter at startup.\n");
                     } else {
-                        ShellStart.terminal.output("\nWarning: Results have been truncated to: " + SparkSessionManager.COLLECT_ITEM_LIMIT
+                        Main.terminal.output("\nWarning: Results have been truncated to: " + SparkSessionManager.COLLECT_ITEM_LIMIT
                                 + " items. This value can be configured with the --result-size parameter at startup.\n");
                     }
                 }

--- a/src/main/java/sparksoniq/jsoniq/runtime/iterator/SparkRuntimeIterator.java
+++ b/src/main/java/sparksoniq/jsoniq/runtime/iterator/SparkRuntimeIterator.java
@@ -22,7 +22,6 @@ package sparksoniq.jsoniq.runtime.iterator;
 import org.apache.spark.api.java.JavaRDD;
 
 import sparksoniq.Main;
-import sparksoniq.ShellStart;
 import sparksoniq.exceptions.IteratorFlowException;
 import sparksoniq.io.json.JiqsItemParser;
 import sparksoniq.jsoniq.item.Item;


### PR DESCRIPTION
- Deprecate ShellStart class, replacing with --shell yes CLI parameter on the Main class.

- Add usage and examples when no parameters are used, made sure usage also appears when using java without spark-submit.

- Clean up and unify use of the CLI parameters into the SparksoniqRuntimeConfiguration class

- ShellStart still works and redirect to Main